### PR TITLE
Add CMD Market PRD and align active design docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ CMD Market is currently a frontend-first Turborepo scaffold for a future marketp
 ## Runtime Boundaries
 
 - The only runtime app today is the web frontend in `apps/web`.
-- There is no backend, worker, database, or external marketplace integration in this repo yet.
+- There is no backend, worker, or database in this repo yet.
 - Tailwind PostCSS config is kept local to `apps/web` because Next.js 16 Turbopack expects app-local PostCSS wiring.
 
 ## Key Flows

--- a/docs/audience.md
+++ b/docs/audience.md
@@ -13,14 +13,14 @@ CMD Market's current primary audience is existing OpenClaw users who want the ea
 
 1. **Primary: OpenClaw-native seller.** Existing OpenClaw user or agent-comfortable seller who wants to list through an agent instead of doing manual marketplace work.
 2. **Secondary: Reseller / power seller.** The clearest adjacent commercial segment because the workflow pain is strong and the search intent is explicit.
-3. **Tertiary: OpenClaw-native buyer / operator.** Buyer who wants agent-mediated discovery across CMD Market listings and affiliate-linked marketplace inventory.
+3. **Tertiary: OpenClaw-native buyer / operator.** Buyer who wants agent-mediated discovery and checkout on native CMD Market inventory.
 4. **Expansion: Mainstream casual seller.** Large eventual market, but not the current core audience because today's value prop assumes agent adoption.
 
 ## Primary Persona: OpenClaw-native Seller
 
 - Already uses OpenClaw or is comfortable delegating selling tasks to an agent.
 - Wants the easiest path from one image upload to a structured, market-ready listing.
-- Values automation, structured inventory, and the ability to turn one listing into multiple marketplace-ready outputs.
+- Values automation, structured inventory, and the ability to turn one image upload into a native CMD Market listing with minimal manual work.
 - Is willing to try a new workflow if it dramatically reduces manual listing effort.
 - Can be casual or professional; the defining trait is agent comfort, not seller scale.
 - Search caveat: Ahrefs does not provide a strong direct signal for OpenClaw-native phrasing, so this persona is driven more by current product truth than by public keyword demand.
@@ -31,27 +31,22 @@ CMD Market's current primary audience is existing OpenClaw users who want the ea
 
 ## Secondary Persona: Reseller / Power Seller
 
-- Already understands multi-marketplace selling and feels duplicate listing pain sharply.
-- Most likely adjacent segment to pay for workflow acceleration, cross-listing, and marketplace coverage.
+- Already understands online resale and feels listing friction sharply.
+- Most likely adjacent segment to pay for workflow acceleration, structured inventory, and faster listing throughput.
 - Strong overlap with the primary audience when the reseller is already automation-friendly or already active in OpenClaw.
 - More likely than casual sellers to compare features, pricing, and time saved across tools.
 - Ahrefs signals:
-- `cross listing app` — 600 US volume
-- `free cross listing app` — 350 US volume
-- `best cross listing app for resellers` — 200 US volume
-- `cross listing app for resellers` — 150 US volume
-- `sell on multiple marketplaces` — 150 US volume
+- `best app to sell stuff` — 700 US volume
+- `sell clothes online` — 3,300 US volume
+- `how to sell used items online` — 150 US volume
 
 ## Buyer Persona: OpenClaw-native Buyer / Operator
 
-- Uses an agent to search structured used-goods inventory faster than manual marketplace hopping.
-- Wants broad discovery across CMD Market native listings plus affiliate-linked results from larger marketplaces.
-- Cares about agent-readable structure, cleaner retrieval, and the ability to discover supply that would otherwise stay fragmented.
-- The current buyer wedge is agent-mediated discovery, even though the broader public search demand shows up in manual search phrasing.
-- Underlying search-demand signals:
-- `search all craigslist` — 2,800 US volume
-- `search all of craigslist` — 1,400 US volume
-- `search facebook marketplace nationwide` — 150 US volume
+- Uses an agent to search structured used-goods inventory faster than manual marketplace browsing.
+- Wants native CMD Market inventory to be cleanly structured for discovery, checkout, and post-purchase tracking.
+- Cares about agent-readable structure, cleaner retrieval, and a smoother path from discovery to purchase.
+- The current buyer wedge is agent-mediated discovery and commerce, even though the broader public search demand shows up in manual search phrasing.
+- Underlying search-demand signals for buyers are still noisy and often phrased around generic marketplace-search behavior rather than clean native-marketplace intent.
 
 ## Expansion Persona: Mainstream Casual Seller
 
@@ -69,24 +64,24 @@ CMD Market's current primary audience is existing OpenClaw users who want the ea
 
 - Sell through an agent instead of manually drafting every listing from scratch.
 - Convert one image upload into structured, market-ready inventory.
-- Reach buyers across CMD Market and other marketplaces without duplicate manual entry.
-- Search fragmented supply through agent-readable inventory and agent-mediated discovery.
-- Reduce the decision fatigue of where to list, where to search, and how much manual work is required.
+- Reach buyers on CMD Market without redundant listing busywork.
+- Search native supply through agent-readable inventory and agent-mediated discovery.
+- Reduce the decision fatigue of where to list, how to publish, and how much manual work is required.
 
 ## Pain Points and Objections
 
-- Manual listing across marketplaces is repetitive and slow.
+- Manual listing is repetitive and slow.
 - Agent-curious sellers worry about trust, accuracy, and control when an agent generates listing drafts.
 - Non-OpenClaw sellers may see the agent step as extra setup friction.
 - Resellers compare free and paid tooling aggressively.
-- Buyers are frustrated by weak cross-market search and one-site-at-a-time browsing.
+- Buyers are frustrated by weak marketplace search and one-site-at-a-time browsing.
 
 ## Customer Language
 
 - Current core-user language to test in product and marketing copy: `sell through an agent`, `list through OpenClaw`, `one image to market-ready listing`, `agent-readable inventory`
-- Search-proven seller language: `cross listing app`, `free cross listing app`, `sell on multiple marketplaces`, `best app to sell stuff`, `best app to sell clothes`
-- Search-proven buyer language: `search all craigslist`, `search all of craigslist`, `search facebook marketplace nationwide`
-- Words to lean on: `sell through agents`, `list once`, `reach more buyers`, `structured inventory`, `search across marketplaces`
+- Search-proven seller language: `best app to sell stuff`, `best app to sell clothes`, `sell clothes online`, `how to sell used items online`
+- Search-proven buyer language is still too marketplace-specific and noisy to use directly as CMD Market positioning.
+- Words to lean on: `sell through agents`, `list faster`, `reach CMD Market buyers`, `structured inventory`, `agent-friendly marketplace`
 - Words to avoid on broad top-of-funnel pages: `omnichannel`, `catalog syndication`, `inventory orchestration`
 
 ## Implications for CMD Market
@@ -95,7 +90,7 @@ CMD Market's current primary audience is existing OpenClaw users who want the ea
 - Speak directly to existing OpenClaw users on the homepage, onboarding, and early growth loops.
 - Treat reseller language as the strongest adjacent acquisition wedge because the problem and willingness to pay are easier to observe.
 - Treat broader casual-seller language as expansion demand, not as the current core user.
-- Buyer messaging should emphasize agent-mediated discovery plus structured inventory, not only generic marketplace aggregation.
+- Buyer messaging should emphasize agent-mediated discovery plus structured inventory, not generic aggregation claims.
 - The clearest honest promise right now is: if you already use OpenClaw, CMD Market makes selling through agents dramatically easier.
 
 ## Anti-Personas

--- a/docs/plans/active/2026-03-22-marketplace-database-design-erd.mmd
+++ b/docs/plans/active/2026-03-22-marketplace-database-design-erd.mmd
@@ -1,0 +1,151 @@
+erDiagram
+    user ||--o{ member : joins
+    organization ||--o{ member : has
+    organization ||--o{ invitation : issues
+    organization ||--o{ apikey : owns
+    organization ||--|| seller_account : maps_to
+    seller_account ||--|| seller_profile : exposes
+    seller_account ||--|| seller_policy : configures
+    seller_account ||--o{ seller_social_verification : verifies
+    seller_account ||--o{ seller_payout_method : pays_out_to
+    seller_account ||--o{ listing : owns
+    category ||--o{ category_attribute : enables
+    attribute_definition ||--o{ category_attribute : defines
+    listing ||--o{ listing_media : contains
+    listing ||--o{ listing_attribute_value : describes
+    category_attribute ||--o{ listing_attribute_value : constrains
+    listing ||--o{ listing_reservation : reserves
+    seller_account ||--o{ order : sells_to
+    user ||--o{ order : places
+    order ||--|{ order_item : contains
+    order ||--|| order_shipping_address : ships_to
+    order ||--o{ payment_intent : pays_with
+    payment_intent ||--o{ payment_attempt : attempts
+    order ||--o| shipment : fulfills
+    order ||--o{ refund : refunds
+    order ||--o{ dispute : disputes
+    order ||--o| seller_feedback : yields
+    seller_account ||--o{ seller_feedback : receives
+    user ||--o{ seller_feedback : leaves
+    seller_account ||--o{ audit_event : affects
+    order ||--o{ ledger_transaction : references
+    payment_intent ||--o{ ledger_transaction : references
+    ledger_transaction ||--|{ ledger_entry : contains
+    ledger_account ||--o{ ledger_entry : posts_to
+    seller_account ||--o{ payout : receives
+    seller_payout_method ||--o{ payout : routes
+
+    user {
+        text id PK
+        text email
+        boolean emailVerified
+    }
+
+    organization {
+        text id PK
+        text name
+        text slug
+    }
+
+    apikey {
+        text id PK
+        text referenceId
+        text name
+        boolean enabled
+    }
+
+    seller_account {
+        uuid id PK
+        text organization_id FK
+        text status
+        text listing_eligibility_status
+        text listing_eligibility_source
+    }
+
+    seller_social_verification {
+        uuid id PK
+        uuid seller_account_id FK
+        text platform
+        text handle
+        bigint follower_count_snapshot
+        text status
+    }
+
+    category {
+        uuid id PK
+        text slug
+        text name
+    }
+
+    attribute_definition {
+        uuid id PK
+        text key
+        text value_type
+    }
+
+    category_attribute {
+        uuid id PK
+        uuid category_id FK
+        uuid attribute_definition_id FK
+        boolean is_required
+    }
+
+    listing {
+        uuid id PK
+        uuid seller_account_id FK
+        uuid category_id FK
+        text title
+        bigint unit_price_minor
+        int quantity_available
+        text status
+    }
+
+    order {
+        uuid id PK
+        uuid seller_account_id FK
+        text buyer_user_id FK
+        bigint total_minor
+        text selected_payment_rail
+        text status
+    }
+
+    payment_intent {
+        uuid id PK
+        uuid order_id FK
+        text rail
+        text settlement_asset_code
+        numeric settlement_amount_atomic
+        text status
+    }
+
+    ledger_account {
+        uuid id PK
+        text owner_type
+        text purpose
+        text asset_code
+    }
+
+    ledger_transaction {
+        uuid id PK
+        text type
+        uuid order_id FK
+        uuid payment_intent_id FK
+    }
+
+    payout {
+        uuid id PK
+        uuid seller_account_id FK
+        uuid seller_payout_method_id FK
+        text asset_code
+        numeric amount_atomic
+        text status
+    }
+
+    seller_feedback {
+        uuid id PK
+        uuid order_id FK
+        uuid seller_account_id FK
+        text buyer_user_id FK
+        smallint rating
+        text status
+    }

--- a/docs/plans/active/2026-03-22-marketplace-database-design-settlement-flow.mmd
+++ b/docs/plans/active/2026-03-22-marketplace-database-design-settlement-flow.mmd
@@ -1,0 +1,21 @@
+flowchart TD
+    A[Buyer places order] --> B[Create payment_intent]
+    B --> C{Selected rail}
+    C -->|Stripe| D[Create Stripe payment attempt]
+    C -->|BTCPay Server| E[Create BTC payment attempt]
+    C -->|NEAR Intents| F[Create NEAR payment attempt]
+    D --> G[Provider confirms payment]
+    E --> G
+    F --> G
+    G --> H[Create ledger_transaction: payment_received]
+    H --> I[Credit platform escrow or seller held accounts]
+    I --> J[Order status becomes paid]
+    J --> K[Seller ships item]
+    K --> L[Carrier marks shipment delivered]
+    L --> M[Cooling-off window elapses]
+    M --> N{Dispute or refund before release?}
+    N -->|No| O[Create ledger_transaction: hold_released]
+    O --> P[Create payout]
+    P --> Q[Payout confirmed]
+    N -->|Yes| R[Create ledger_transaction: refund_issued or dispute_reserved]
+    R --> S[Refund buyer or continue review]

--- a/docs/plans/active/2026-03-22-marketplace-database-design-states.mmd
+++ b/docs/plans/active/2026-03-22-marketplace-database-design-states.mmd
@@ -1,0 +1,41 @@
+stateDiagram-v2
+    [*] --> ListingDraft
+
+    ListingDraft --> ListingPublished: publish
+    ListingPublished --> ListingReserved: reservation created
+    ListingReserved --> ListingPublished: reservation released
+    ListingReserved --> ListingSold: order paid
+    ListingPublished --> ListingCancelled: seller/admin cancel
+    ListingPublished --> ListingExpired: expiration policy
+
+    ListingSold --> [*]
+    ListingCancelled --> [*]
+    ListingExpired --> [*]
+
+    --
+
+    state "Order Lifecycle" as OrderLifecycle {
+        [*] --> PendingPayment
+        PendingPayment --> Paid: payment_intent confirmed
+        PendingPayment --> Cancelled: timeout or manual cancel
+        Paid --> FulfillmentPending: hold created
+        FulfillmentPending --> Shipped: shipment confirmed
+        Shipped --> Delivered: carrier delivery
+        Delivered --> Completed: review window closes and payout released
+        Paid --> Refunded: refund before shipment
+        FulfillmentPending --> Disputed: issue opened
+        Shipped --> Disputed: issue opened
+        Delivered --> Disputed: issue opened
+        Disputed --> Completed: seller wins
+        Disputed --> Refunded: buyer wins
+    }
+
+    --
+
+    state "Payout Lifecycle" as PayoutLifecycle {
+        [*] --> Held
+        Held --> Eligible: shipment and policy conditions satisfied
+        Eligible --> Released: payout submitted and confirmed
+        Held --> Reversed: refund or dispute before release
+        Released --> Reversed: recovery or post-release adjustment
+    }

--- a/docs/plans/active/2026-03-22-marketplace-database-design.md
+++ b/docs/plans/active/2026-03-22-marketplace-database-design.md
@@ -1,0 +1,1036 @@
+# CMD Market Marketplace Database Design
+
+**Date:** 2026-03-22
+
+## Summary
+
+This document defines the planned PostgreSQL database design for CMD Market as an agent-first, seller-driven marketplace for physical goods. It is the canonical planning artifact until a backend exists in this repository.
+
+The design assumes:
+
+- BetterAuth is the identity baseline.
+- Humans are the primary identities.
+- Seller stores are commerce roots.
+- Agents authenticate with seller-scoped API keys and act on behalf of a seller store.
+- CMD Market runs native marketplace transactions with held funds, payouts, refunds, and disputes.
+
+## Source Of Truth Recommendation
+
+For this repository today, the best place to save database design work is `docs/plans/active/` because the backend and schema do not exist yet. This keeps the document honest: it is a serious design artifact, but it is not runtime truth yet.
+
+Recommended lifecycle:
+
+1. Keep the working schema design here at `docs/plans/active/2026-03-22-marketplace-database-design.md`.
+2. Use this file as the canonical planning document while backend work is still future work.
+3. Once the database is implemented or the design stabilizes, promote the durable truth into a focused doc such as `docs/database.md` and link it from `docs/index.md`.
+
+Markdown with embedded Mermaid diagrams is the canonical format. It is easy to diff, easy to review, easy for agents to parse, and gives us built-in illustrations without needing a second source of truth.
+
+## Goals
+
+- Support BetterAuth-native identity and seller/store memberships.
+- Model seller eligibility using Twitter/X reputation as listing collateral.
+- Support flat categories with category-scoped structured facets.
+- Support fixed-price listings only.
+- Support native checkout, shipping, held funds, payouts, refunds, and disputes.
+- Preserve light provenance and auditability for agent-created writes.
+- Stay narrow on v1 scope by explicitly excluding auctions, native buyer-seller messaging, KYC-first onboarding, and a full AI draft pipeline.
+
+## Design Principles
+
+### 1. BetterAuth owns identity
+
+BetterAuth tables remain the source of truth for auth identity and session state:
+
+- `user`
+- `session`
+- `account`
+- `verification`
+- `organization`
+- `member`
+- `invitation`
+- `apikey`
+
+We do not replace those tables with marketplace-specific versions.
+
+### 2. Seller stores are commerce roots
+
+Commerce records should not hang directly off BetterAuth users. Listings, balances, payout settings, and policy state belong to a dedicated `seller_account` that is linked 1:1 with a BetterAuth `organization`.
+
+This gives us:
+
+- one marketplace root for ownership and balances
+- clean seller-scoped agent credentials
+- future room for richer seller-account collaboration if the product earns it later
+- separation between auth concerns and commerce concerns
+
+### 3. Agent access is seller-scoped
+
+Agents authenticate with BetterAuth API keys configured with `references: "organization"`. In CMD Market terms, the organization is the auth-side representation of the seller store.
+
+Agent actions should still be attributable in marketplace tables and audit logs. We want to know whether a mutation came from:
+
+- a human session
+- a seller-scoped API key
+- a system/admin process
+
+### 4. Flat categories, structured facets
+
+CMD Market should not recreate eBay's deep taxonomy. The catalog model uses:
+
+- a flat category list
+- category-scoped attribute definitions
+- typed listing attribute values
+
+This avoids a deep tree while still giving agents and filters structured inventory.
+
+### 5. Money is stored as exact atomic units
+
+Do not store money as floating point values.
+
+Use:
+
+- fiat display prices in minor units, such as cents
+- settlement and ledger amounts in atomic units per asset
+- explicit asset or currency codes on all monetary records
+
+This matters because the marketplace may price an item in one display currency while settling it through Stripe, BTC, or NEAR-based rails.
+
+### 6. Object storage uses DigitalOcean Spaces
+
+Seller profile assets and listing media should live in DigitalOcean Spaces.
+
+Spaces-specific assumptions:
+
+- Spaces is treated as S3-compatible object storage
+- the database stores stable object keys, not presigned upload URLs
+- public asset URLs are derived at read time from a CDN or custom asset host in front of Spaces
+- upload lifecycle belongs in the API and storage layer, not in extra provider-specific database tables for v1
+
+### 7. Light provenance, not a full AI pipeline
+
+We need enough auditability to know who or what wrote important records, but we do not need separate tables for model runs, extraction runs, or draft-run lineage yet.
+
+The design should prefer:
+
+- explicit actor references on key marketplace records
+- `audit_event` for historical traceability
+
+## Naming And ID Conventions
+
+- Keep BetterAuth table names exactly as BetterAuth defines them.
+- Use singular snake_case names for custom marketplace tables.
+- Use UUIDv7 for custom marketplace primary keys.
+- Use text foreign keys when referencing BetterAuth-owned IDs so they match BetterAuth's chosen ID type.
+- Include `created_at` and `updated_at` on nearly all custom tables.
+- Use `deleted_at` only where soft delete materially improves recovery or auditability.
+
+## Auth Boundary
+
+### BetterAuth Core Tables
+
+- `user`: human identity root
+- `session`: browser or session-based auth
+- `account`: external login providers
+- `verification`: verification tokens and flows
+
+### BetterAuth Organization Tables
+
+- `organization`: auth-side representation of a seller store
+- `member`: membership and role assignment inside the store
+- `invitation`: store invitations
+
+Defer BetterAuth's optional `team` and `teamMember` tables. Organization membership is enough for v1.
+
+### BetterAuth API Key Table
+
+Use the BetterAuth API key plugin with organization references so seller-scoped tokens map cleanly onto store ownership.
+
+Recommended configuration assumption:
+
+- `references: "organization"`
+- API key permissions stored in plugin-supported permissions or metadata
+- rate limits enabled per key
+
+### Custom Audit Table
+
+Add one marketplace-owned audit table:
+
+#### `audit_event`
+
+Purpose:
+
+- preserve a durable trail of important seller, listing, order, payment, payout, and dispute mutations
+
+Key fields:
+
+- `id`
+- `entity_table`
+- `entity_id`
+- `action`
+- `actor_type` (`user`, `api_key`, `system`, `admin`)
+- `actor_user_id` nullable
+- `actor_api_key_id` nullable
+- `seller_account_id` nullable
+- `metadata_json`
+- `created_at`
+
+## Seller And Trust Model
+
+### `seller_account`
+
+Purpose:
+
+- commerce root for a seller store
+
+Key fields:
+
+- `id`
+- `organization_id` unique FK -> `organization.id`
+- `status` (`active`, `suspended`, `closed`)
+- `listing_eligibility_status` (`pending`, `eligible`, `revoked`, `suspended`)
+- `listing_eligibility_source` (`x_verification`, `manual_override`)
+- `listing_eligibility_note` nullable
+- `default_display_currency_code`
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- Listings, balances, payout methods, and seller policy should reference `seller_account.id`.
+- This is the root boundary for permissions and reconciliation.
+- `listing_eligibility_source` makes it explicit whether the seller is eligible because of Twitter/X verification or the manual override path.
+
+### `seller_profile`
+
+Purpose:
+
+- public-facing seller/store metadata
+
+Key fields:
+
+- `seller_account_id` unique FK
+- `display_name`
+- `slug` unique
+- `bio`
+- `avatar_asset_key`
+- `banner_asset_key`
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- `avatar_asset_key` and `banner_asset_key` are DigitalOcean Spaces object keys, not public URLs.
+- Public URLs should be derived at read time from the configured asset host.
+
+### `seller_policy`
+
+Purpose:
+
+- store-specific marketplace behavior defaults
+
+Key fields:
+
+- `seller_account_id` unique FK
+- `handling_time_days`
+- `return_window_days`
+- `payout_hold_days`
+- `created_at`
+- `updated_at`
+
+### `seller_social_verification`
+
+Purpose:
+
+- record the Twitter/X-based listing gate
+
+Key fields:
+
+- `id`
+- `seller_account_id` FK
+- `platform` (`x`)
+- `external_account_id`
+- `handle`
+- `follower_count_snapshot`
+- `required_threshold_snapshot`
+- `status` (`pending`, `verified`, `revoked`, `failed`, `expired`)
+- `verified_at`
+- `expires_at` nullable
+- `revoked_at` nullable
+- `raw_payload_json`
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- At most one active verified record per seller and platform should exist at a time.
+- The follower count snapshot is important because policy can change later.
+- Eligibility is normally granted through a verified Twitter/X record; manual approval should update `seller_account.listing_eligibility_*` without requiring a fake social verification row.
+
+### `seller_payout_method`
+
+Purpose:
+
+- seller destination for payout releases
+
+Key fields:
+
+- `id`
+- `seller_account_id` FK
+- `rail` (`stripe`, `btcpay`, `near_intents`)
+- `network`
+- `destination_reference`
+- `destination_label`
+- `status` (`active`, `disabled`, `pending`)
+- `is_default`
+- `metadata_json`
+- `created_at`
+- `updated_at`
+
+## Catalog And Discovery Model
+
+### `category`
+
+Purpose:
+
+- flat top-level classification for listings
+
+Key fields:
+
+- `id`
+- `slug` unique
+- `name`
+- `description`
+- `sort_order`
+- `is_active`
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- No parent-child tree in v1.
+- If a deeper taxonomy is ever needed later, add it deliberately rather than leaving a dormant hierarchy now.
+
+### `attribute_definition`
+
+Purpose:
+
+- typed facet definition reusable across categories
+
+Key fields:
+
+- `id`
+- `key` unique
+- `label`
+- `value_type` (`text`, `number`, `boolean`, `enum`, `json`)
+- `unit_label` nullable
+- `configuration_json`
+- `created_at`
+- `updated_at`
+
+### `category_attribute`
+
+Purpose:
+
+- category-scoped enablement and rules for an attribute
+
+Key fields:
+
+- `id`
+- `category_id` FK
+- `attribute_definition_id` FK
+- `is_required`
+- `is_filterable`
+- `is_sortable`
+- `sort_order`
+- `allowed_values_json` nullable
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- Unique on (`category_id`, `attribute_definition_id`)
+- This is how we avoid uncontrolled EAV while still supporting flexible structured inventory.
+
+### `listing`
+
+Purpose:
+
+- public marketplace listing for a physical item
+
+Key fields:
+
+- `id`
+- `seller_account_id` FK
+- `category_id` FK
+- `title`
+- `description`
+- `condition_code`
+- `quantity_available`
+- `unit_price_minor`
+- `display_currency_code`
+- `status` (`draft`, `published`, `reserved`, `sold`, `cancelled`, `expired`)
+- `published_at` nullable
+- `closed_at` nullable
+- `created_by_user_id` nullable FK -> `user.id`
+- `created_by_api_key_id` nullable FK -> `apikey.id`
+- `updated_by_user_id` nullable FK -> `user.id`
+- `updated_by_api_key_id` nullable FK -> `apikey.id`
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- Listings are mostly one-off physical goods, but `quantity_available > 1` is allowed.
+- No auction-specific fields belong here in v1.
+
+### `listing_media`
+
+Purpose:
+
+- ordered media assets for a listing
+
+Key fields:
+
+- `id`
+- `listing_id` FK
+- `asset_key`
+- `asset_type`
+- `alt_text`
+- `sort_order`
+- `created_at`
+
+Notes:
+
+- `asset_key` is the canonical DigitalOcean Spaces object key for the asset.
+- Do not persist presigned upload URLs in marketplace tables.
+- Public media URLs should be derived from `asset_key` through the configured CDN or asset host.
+
+### `listing_attribute_value`
+
+Purpose:
+
+- typed structured attributes attached to a listing
+
+Key fields:
+
+- `id`
+- `listing_id` FK
+- `category_attribute_id` FK
+- `value_text` nullable
+- `value_number` nullable
+- `value_boolean` nullable
+- `value_json` nullable
+- `normalized_text` nullable
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- Unique on (`listing_id`, `category_attribute_id`)
+- Only one value column should be populated according to the mapped attribute type.
+
+### `listing_reservation`
+
+Purpose:
+
+- temporary quantity hold to prevent oversell during in-flight checkout
+
+Key fields:
+
+- `id`
+- `listing_id` FK
+- `order_id` nullable FK
+- `quantity`
+- `status` (`active`, `released`, `consumed`, `expired`)
+- `expires_at`
+- `created_at`
+- `updated_at`
+
+## Order Flow
+
+### `order`
+
+Purpose:
+
+- marketplace transaction root between one buyer and one seller
+
+Key fields:
+
+- `id`
+- `seller_account_id` FK
+- `buyer_user_id` FK -> `user.id`
+- `status` (`pending_payment`, `paid`, `fulfillment_pending`, `shipped`, `delivered`, `completed`, `refunded`, `disputed`, `cancelled`)
+- `display_currency_code`
+- `subtotal_minor`
+- `shipping_minor`
+- `platform_fee_minor`
+- `total_minor`
+- `selected_payment_rail`
+- `placed_at`
+- `completed_at` nullable
+- `cancelled_at` nullable
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- Keep orders seller-scoped. Multi-seller carts are out of scope for v1.
+
+### `order_item`
+
+Purpose:
+
+- immutable purchase snapshot for items in an order
+
+Key fields:
+
+- `id`
+- `order_id` FK
+- `listing_id` nullable FK
+- `quantity`
+- `unit_price_minor`
+- `display_currency_code`
+- `title_snapshot`
+- `description_snapshot`
+- `condition_snapshot`
+- `attribute_snapshot_json`
+- `media_snapshot_json`
+- `created_at`
+
+Notes:
+
+- Even if the original listing changes later, the order item snapshot must stay stable for support, refunds, and disputes.
+
+### `order_shipping_address`
+
+Purpose:
+
+- immutable shipping destination snapshot
+
+Key fields:
+
+- `order_id` unique FK
+- `recipient_name`
+- `line_1`
+- `line_2`
+- `city`
+- `region`
+- `postal_code`
+- `country_code`
+- `phone_number`
+- `created_at`
+
+## Payment And Ledger Model
+
+### `payment_intent`
+
+Purpose:
+
+- buyer-facing payment object for an order
+
+Key fields:
+
+- `id`
+- `order_id` FK
+- `rail` (`stripe`, `btcpay`, `near_intents`)
+- `status` (`created`, `pending`, `confirmed`, `failed`, `expired`, `cancelled`, `refunded`)
+- `display_currency_code`
+- `display_amount_minor`
+- `settlement_asset_code`
+- `settlement_amount_atomic`
+- `settlement_asset_decimals`
+- `quote_metadata_json`
+- `external_reference`
+- `expires_at`
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- An order may have multiple payment intents over time, but only one should be active at a time.
+- This table is where display pricing and rail-specific settlement amounts meet.
+
+### `payment_attempt`
+
+Purpose:
+
+- provider-specific attempt or observation under a payment intent
+
+Key fields:
+
+- `id`
+- `payment_intent_id` FK
+- `provider_reference`
+- `status` (`created`, `submitted`, `observed`, `settled`, `failed`, `expired`)
+- `raw_payload_json`
+- `observed_at` nullable
+- `created_at`
+- `updated_at`
+
+### `ledger_account`
+
+Purpose:
+
+- balance bucket for marketplace money state
+
+Key fields:
+
+- `id`
+- `owner_type` (`platform`, `seller_account`, `order`, `refund`, `fee`)
+- `owner_id`
+- `purpose` (`seller_available`, `seller_held`, `platform_escrow`, `platform_fee`, `refund_liability`)
+- `asset_code`
+- `asset_decimals`
+- `status` (`active`, `closed`)
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- A seller should typically have separate held and available accounts per asset.
+
+### `ledger_transaction`
+
+Purpose:
+
+- balanced financial event header
+
+Key fields:
+
+- `id`
+- `type` (`payment_received`, `hold_created`, `hold_released`, `fee_assessed`, `refund_issued`, `payout_sent`, `dispute_reserved`, `dispute_released`)
+- `order_id` nullable FK
+- `payment_intent_id` nullable FK
+- `external_reference` nullable
+- `created_at`
+
+### `ledger_entry`
+
+Purpose:
+
+- individual debit or credit line inside a ledger transaction
+
+Key fields:
+
+- `id`
+- `ledger_transaction_id` FK
+- `ledger_account_id` FK
+- `direction` (`debit`, `credit`)
+- `amount_atomic`
+- `asset_code`
+- `entry_index`
+- `created_at`
+
+Notes:
+
+- Every `ledger_transaction` must balance exactly per asset.
+
+### `payout`
+
+Purpose:
+
+- release of seller funds from held to destination
+
+Key fields:
+
+- `id`
+- `seller_account_id` FK
+- `seller_payout_method_id` FK
+- `ledger_transaction_id` nullable FK
+- `asset_code`
+- `amount_atomic`
+- `status` (`queued`, `submitted`, `confirmed`, `failed`, `reversed`)
+- `external_reference`
+- `released_at` nullable
+- `created_at`
+- `updated_at`
+
+## Fulfillment, Refund, And Dispute Model
+
+### `shipment`
+
+Purpose:
+
+- shipping and delivery state for an order
+
+Key fields:
+
+- `id`
+- `order_id` unique FK
+- `carrier`
+- `service_level`
+- `tracking_number`
+- `status` (`pending`, `label_created`, `shipped`, `delivered`, `returned`, `lost`)
+- `shipped_at` nullable
+- `delivered_at` nullable
+- `last_tracking_at` nullable
+- `tracking_payload_json` nullable
+- `created_at`
+- `updated_at`
+
+### `refund`
+
+Purpose:
+
+- monetary refund associated with an order or payment
+
+Key fields:
+
+- `id`
+- `order_id` FK
+- `payment_intent_id` nullable FK
+- `asset_code`
+- `amount_atomic`
+- `reason_code`
+- `status` (`requested`, `approved`, `submitted`, `confirmed`, `failed`, `cancelled`)
+- `created_at`
+- `updated_at`
+
+### `dispute`
+
+Purpose:
+
+- support and financial review record for contested orders
+
+Key fields:
+
+- `id`
+- `order_id` FK
+- `payment_intent_id` nullable FK
+- `opened_by_user_id` nullable FK -> `user.id`
+- `status` (`open`, `under_review`, `resolved_buyer`, `resolved_seller`, `cancelled`)
+- `reason_code`
+- `resolution_summary`
+- `opened_at`
+- `closed_at` nullable
+- `created_at`
+- `updated_at`
+
+### `seller_feedback`
+
+Purpose:
+
+- buyer-to-seller reputation record for a completed order
+
+Key fields:
+
+- `id`
+- `order_id` unique FK
+- `seller_account_id` FK
+- `buyer_user_id` FK -> `user.id`
+- `rating` smallint
+- `comment` nullable
+- `status` (`published`, `hidden`, `removed`)
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- Only one buyer feedback record should exist per completed order.
+- This table is intentionally one-way: buyers rate sellers, not the reverse.
+
+## Domain Relationships
+
+The key ownership chain is:
+
+- `user` joins `organization` through `member`
+- `organization` maps 1:1 to `seller_account`
+- `seller_account` owns listings, payout methods, policy, social verification, orders as seller, and seller-side balances
+- `apikey` belongs to `organization`, and therefore acts within one seller boundary
+- `listing` belongs to `seller_account`
+- `order` connects buyer `user` to seller `seller_account`
+- `payment_intent`, `shipment`, `refund`, and `dispute` all attach to an `order`
+- `seller_feedback` ties a completed `order` back to the seller reputation surface
+- `ledger_transaction` and `ledger_entry` tie money movement back to order and payment context
+
+## Mermaid ERD
+
+```mermaid
+erDiagram
+    user ||--o{ member : joins
+    organization ||--o{ member : has
+    organization ||--o{ invitation : issues
+    organization ||--o{ apikey : owns
+    organization ||--|| seller_account : maps_to
+    seller_account ||--|| seller_profile : exposes
+    seller_account ||--|| seller_policy : configures
+    seller_account ||--o{ seller_social_verification : verifies
+    seller_account ||--o{ seller_payout_method : pays_out_to
+    seller_account ||--o{ listing : owns
+    category ||--o{ category_attribute : enables
+    attribute_definition ||--o{ category_attribute : defines
+    listing ||--o{ listing_media : contains
+    listing ||--o{ listing_attribute_value : describes
+    category_attribute ||--o{ listing_attribute_value : constrains
+    listing ||--o{ listing_reservation : reserves
+    seller_account ||--o{ order : sells_to
+    user ||--o{ order : places
+    order ||--|{ order_item : contains
+    order ||--|| order_shipping_address : ships_to
+    order ||--o{ payment_intent : pays_with
+    payment_intent ||--o{ payment_attempt : attempts
+    order ||--o| shipment : fulfills
+    order ||--o{ refund : refunds
+    order ||--o{ dispute : disputes
+    order ||--o| seller_feedback : yields
+    seller_account ||--o{ seller_feedback : receives
+    user ||--o{ seller_feedback : leaves
+    seller_account ||--o{ audit_event : affects
+    order ||--o{ ledger_transaction : references
+    payment_intent ||--o{ ledger_transaction : references
+    ledger_transaction ||--|{ ledger_entry : contains
+    ledger_account ||--o{ ledger_entry : posts_to
+    seller_account ||--o{ payout : receives
+    seller_payout_method ||--o{ payout : routes
+
+    user {
+        text id PK
+        text email
+        boolean emailVerified
+    }
+
+    organization {
+        text id PK
+        text name
+        text slug
+    }
+
+    apikey {
+        text id PK
+        text referenceId
+        text name
+        boolean enabled
+    }
+
+    seller_account {
+        uuid id PK
+        text organization_id FK
+        text status
+        text listing_eligibility_status
+        text listing_eligibility_source
+    }
+
+    seller_social_verification {
+        uuid id PK
+        uuid seller_account_id FK
+        text platform
+        text handle
+        bigint follower_count_snapshot
+        text status
+    }
+
+    category {
+        uuid id PK
+        text slug
+        text name
+    }
+
+    attribute_definition {
+        uuid id PK
+        text key
+        text value_type
+    }
+
+    category_attribute {
+        uuid id PK
+        uuid category_id FK
+        uuid attribute_definition_id FK
+        boolean is_required
+    }
+
+    listing {
+        uuid id PK
+        uuid seller_account_id FK
+        uuid category_id FK
+        text title
+        bigint unit_price_minor
+        int quantity_available
+        text status
+    }
+
+    order {
+        uuid id PK
+        uuid seller_account_id FK
+        text buyer_user_id FK
+        bigint total_minor
+        text selected_payment_rail
+        text status
+    }
+
+    payment_intent {
+        uuid id PK
+        uuid order_id FK
+        text rail
+        text settlement_asset_code
+        numeric settlement_amount_atomic
+        text status
+    }
+
+    ledger_account {
+        uuid id PK
+        text owner_type
+        text purpose
+        text asset_code
+    }
+
+    ledger_transaction {
+        uuid id PK
+        text type
+        uuid order_id FK
+        uuid payment_intent_id FK
+    }
+
+    payout {
+        uuid id PK
+        uuid seller_account_id FK
+        uuid seller_payout_method_id FK
+        text asset_code
+        numeric amount_atomic
+        text status
+    }
+
+    seller_feedback {
+        uuid id PK
+        uuid order_id FK
+        uuid seller_account_id FK
+        text buyer_user_id FK
+        smallint rating
+        text status
+    }
+```
+
+## Listing, Order, Payment, And Payout States
+
+```mermaid
+stateDiagram-v2
+    [*] --> ListingDraft
+
+    ListingDraft --> ListingPublished: publish
+    ListingPublished --> ListingReserved: reservation created
+    ListingReserved --> ListingPublished: reservation released
+    ListingReserved --> ListingSold: order paid
+    ListingPublished --> ListingCancelled: seller/admin cancel
+    ListingPublished --> ListingExpired: expiration policy
+
+    ListingSold --> [*]
+    ListingCancelled --> [*]
+    ListingExpired --> [*]
+
+    --
+
+    state "Order Lifecycle" as OrderLifecycle {
+        [*] --> PendingPayment
+        PendingPayment --> Paid: payment_intent confirmed
+        PendingPayment --> Cancelled: timeout or manual cancel
+        Paid --> FulfillmentPending: hold created
+        FulfillmentPending --> Shipped: shipment confirmed
+        Shipped --> Delivered: carrier delivery
+        Delivered --> Completed: review window closes and payout released
+        Paid --> Refunded: refund before shipment
+        FulfillmentPending --> Disputed: issue opened
+        Shipped --> Disputed: issue opened
+        Delivered --> Disputed: issue opened
+        Disputed --> Completed: seller wins
+        Disputed --> Refunded: buyer wins
+    }
+
+    --
+
+    state "Payout Lifecycle" as PayoutLifecycle {
+        [*] --> Held
+        Held --> Eligible: shipment and policy conditions satisfied
+        Eligible --> Released: payout submitted and confirmed
+        Held --> Reversed: refund or dispute before release
+        Released --> Reversed: recovery or post-release adjustment
+    }
+```
+
+## Payment And Settlement Flow
+
+```mermaid
+flowchart TD
+    A[Buyer places order] --> B[Create payment_intent]
+    B --> C{Selected rail}
+    C -->|Stripe| D[Create Stripe payment attempt]
+    C -->|BTCPay Server| E[Create BTC payment attempt]
+    C -->|NEAR Intents| F[Create NEAR payment attempt]
+    D --> G[Provider confirms payment]
+    E --> G
+    F --> G
+    G --> H[Create ledger_transaction: payment_received]
+    H --> I[Credit platform escrow or seller held accounts]
+    I --> J[Order status becomes paid]
+    J --> K[Seller ships item]
+    K --> L[Carrier marks shipment delivered]
+    L --> M[Cooling-off window elapses]
+    M --> N{Dispute or refund before release?}
+    N -->|No| O[Create ledger_transaction: hold_released]
+    O --> P[Create payout]
+    P --> Q[Payout confirmed]
+    N -->|Yes| R[Create ledger_transaction: refund_issued or dispute_reserved]
+    R --> S[Refund buyer or continue review]
+```
+
+## Indexing And Constraint Strategy
+
+### Core constraints
+
+- Unique `seller_account.organization_id`
+- Unique `seller_profile.slug`
+- Unique active `seller_social_verification` per seller and platform
+- Unique (`category_id`, `attribute_definition_id`) on `category_attribute`
+- Unique (`listing_id`, `category_attribute_id`) on `listing_attribute_value`
+- Unique active shipment per order
+- Balanced `ledger_entry` totals per `ledger_transaction` and asset
+
+### Core indexes
+
+- `listing (seller_account_id, status, published_at desc)`
+- `listing (category_id, status, published_at desc)`
+- `order (seller_account_id, status, created_at desc)`
+- `order (buyer_user_id, status, created_at desc)`
+- `payment_intent (order_id, status, created_at desc)`
+- `payment_attempt (provider_reference)`
+- `seller_social_verification (seller_account_id, platform, status)`
+- `ledger_entry (ledger_account_id, created_at desc)`
+- `audit_event (entity_table, entity_id, created_at desc)`
+- `audit_event (seller_account_id, created_at desc)`
+
+### Search and filtering notes
+
+- Keep category and seller lookups indexed by slug.
+- Add partial indexes for published listings only if listing volume justifies it.
+- Prefer structured facet indexes on high-value category attributes instead of a generic index-everything approach.
+
+## Validation Scenarios
+
+Future implementation should be considered correct only if the schema supports these scenarios cleanly:
+
+1. A human joins a seller organization, and that organization maps to exactly one `seller_account`.
+2. A seller-scoped API key can create or update listings only inside its own seller boundary.
+3. A seller cannot publish a listing until seller eligibility is granted by either verified `seller_social_verification` or the manual approval override path on `seller_account`.
+4. A listing can carry category-specific typed attributes without turning into a free-form EAV blob.
+5. Concurrent checkouts cannot oversell quantity because `listing_reservation` captures temporary holds.
+6. An order can move from placed to paid to shipped to completed while held funds release only after carrier delivery and the cooling-off policy are satisfied.
+7. A refund or dispute can interrupt payout release and create correct ledger side effects.
+8. Stripe, BTCPay Server, and NEAR Intents can all be recorded without collapsing rail-specific data into the core order table.
+9. Only buyers with completed orders can leave one feedback record per order, and seller reputation can be read without exposing buyer private data.
+
+## Deferred Scope
+
+Explicitly not modeled in this design:
+
+- auctions
+- native buyer-seller messaging
+- KYC-before-listing onboarding
+- full AI extraction or draft-run provenance tables
+- BetterAuth team tables
+- multi-seller carts
+
+## References
+
+- BetterAuth Database: https://better-auth.com/docs/concepts/database
+- BetterAuth Organization plugin: https://better-auth.com/docs/plugins/organization
+- BetterAuth API Key plugin: https://better-auth.com/docs/plugins/api-key
+- BetterAuth API Key plugin reference: https://better-auth.com/docs/plugins/api-key/reference

--- a/docs/plans/active/2026-03-25-marketplace-api-design.md
+++ b/docs/plans/active/2026-03-25-marketplace-api-design.md
@@ -1,0 +1,1308 @@
+# CMD Market Marketplace API Design
+
+**Date:** 2026-03-25
+
+## Summary
+
+This document defines the planned API design for CMD Market as an agent-first marketplace for physical goods. It is the canonical API planning artifact until a backend exists in this repository.
+
+The design assumes:
+
+- the current runtime host is the Next.js app in `apps/web`
+- the database design in `docs/plans/active/2026-03-22-marketplace-database-design.md` is the persistence baseline
+- BetterAuth owns identity, sessions, organizations, anonymous users, and API keys
+- public discovery is open
+- write operations require either a BetterAuth session or a seller-scoped BetterAuth API key
+
+## Source Of Truth Recommendation
+
+For this repository today, the right place for the API design is `docs/plans/active/` because the API is still future work and there is no backend implementation yet.
+
+Recommended lifecycle:
+
+1. Keep the working API design here at `docs/plans/active/2026-03-25-marketplace-api-design.md`.
+2. Keep this document paired with the active database design while backend work does not yet exist.
+3. Once the API contract is implemented or stabilized, promote the durable truth into a focused doc such as `docs/api.md` and link it from `docs/index.md`.
+
+Markdown is the canonical format. Mermaid diagrams live directly in the document so the API design stays reviewable, diffable, and easy for both humans and agents to consume.
+
+## Goals
+
+- define a single JSON HTTP API shape that works for the web app and agent clients
+- support public listing discovery and authenticated marketplace operations
+- support BetterAuth sessions for humans, anonymous BetterAuth sessions for guest buyers, and seller-scoped BetterAuth API keys for seller agents
+- keep the contract resource-oriented, not RPC-style
+- support draft-first listing creation with DigitalOcean Spaces-backed media upload sessions
+- support async order and payment flows with Stripe, BTCPay Server, and NEAR Intents
+- standardize pagination, filtering, idempotency, and error responses
+
+## Design Principles
+
+### 1. One API, one canonical resource model
+
+CMD Market should not have separate public web and agent APIs for the same core resources.
+
+The public API should expose one canonical JSON representation for:
+
+- listings
+- sellers
+- categories
+- orders
+- payment intents
+
+The web app and buyer agents should consume the same listing and discovery resources. Seller routes may add management metadata, but the underlying commerce objects should remain structurally consistent.
+
+### 2. Public read, authenticated write
+
+Discovery should be easy to crawl and easy to integrate:
+
+- public listing and seller reads are unauthenticated
+- all mutations require authentication
+- buyer commerce operations require a BetterAuth session
+- seller operations require either a seller-scoped BetterAuth API key or a BetterAuth session with a valid seller organization context
+
+### 3. BetterAuth owns identity and credential lifecycle
+
+This API design does not replace BetterAuth's auth surface.
+
+BetterAuth remains responsible for:
+
+- sign in and sign up
+- anonymous sign in
+- session management
+- account linking
+- organization membership
+- active organization selection
+- organization-owned API key creation and revocation
+
+CMD Market builds marketplace resources on top of that identity surface.
+
+### 4. Seller routes resolve through organization context
+
+For seller browser sessions, the active BetterAuth organization is the seller context.
+
+For seller API keys, the organization referenced by the key is the seller context.
+
+Seller routes should not accept an arbitrary seller identifier that can bypass this boundary. If a session user belongs to multiple organizations and no active organization is set, the API should return a contract-level error instead of guessing.
+
+### 5. Guest checkout still uses authenticated sessions
+
+Guest checkout does not mean unauthenticated commerce requests.
+
+The buyer flow uses BetterAuth anonymous sessions so that:
+
+- checkout mutations still have a stable user identity
+- orders remain attached to a real user row
+- later account linking can transfer marketplace ownership to a fully registered account through BetterAuth's anonymous account-link flow
+
+This keeps the API cleaner than introducing separate guest tokens or order recovery credentials.
+
+### 6. Draft-first listing creation
+
+Seller listing creation should be explicit and stateful:
+
+1. create a draft
+2. create media upload sessions
+3. upload assets directly to DigitalOcean Spaces
+4. attach media and structured attributes
+5. publish with validation
+
+This keeps agent and web clients aligned and makes validation failures obvious.
+
+### 7. Media storage uses DigitalOcean Spaces
+
+Listing media and seller profile assets should live in DigitalOcean Spaces.
+
+API-specific assumptions:
+
+- Spaces is treated as S3-compatible object storage
+- upload sessions return presigned S3-compatible upload requests
+- the API and database share `asset_key` as the canonical identifier for uploaded objects
+- public media URLs can be served from a CDN or custom asset host in front of Spaces
+
+### 8. Payments are asynchronous state machines
+
+Order placement and payment settlement must be modeled as state transitions, not as a synchronous “charge card and finish” call.
+
+The public API should create and expose:
+
+- `order`
+- `payment_intent`
+- shipment and fulfillment state
+
+Provider callbacks from Stripe, BTCPay Server, and NEAR Intents are internal implementation details. Public clients observe state through polling the order and payment resources.
+
+### 9. Polling first, no outbound client webhooks
+
+The first public API should not include outbound webhooks for clients.
+
+Clients should poll:
+
+- order status
+- payment intent status
+- shipment status
+- payout status for seller tools
+
+Internal provider callbacks still exist, but they are not part of the public contract.
+
+### 10. Unversioned for now, versionable later
+
+The public API stays unversioned for now to keep the first contract light.
+
+Paths should still be shaped so that a future move from:
+
+- `/api/listings`
+
+to:
+
+- `/api/v1/listings`
+
+is a mechanical migration rather than an API redesign.
+
+## API Boundary
+
+### BetterAuth-Owned Surface
+
+The application relies on BetterAuth for auth endpoints. This design treats those routes as an external auth substrate, not as marketplace endpoints to redesign here.
+
+Relevant BetterAuth capabilities:
+
+- core database and session model
+- organization membership and active organization
+- anonymous sign-in and later account linking
+- organization-owned API keys
+
+Recommended mounting convention:
+
+- BetterAuth auth routes under `/api/auth/*`
+
+This document does not restate every BetterAuth route. It documents how CMD Market marketplace routes rely on them.
+
+### Marketplace-Owned Surface
+
+Marketplace routes live under `/api/*` and split into two broad areas:
+
+- public marketplace surface
+- seller surface under `/api/seller/*`
+
+Public does not mean every route is unauthenticated. It means the route belongs to the marketplace-facing contract rather than a seller-only namespace.
+
+## Auth Matrix
+
+| Surface | Primary clients | Auth mode | Notes |
+| --- | --- | --- | --- |
+| `GET /api/categories`, `GET /api/listings`, `GET /api/sellers/*` | web, buyer agents, crawlers | none | public discovery |
+| `GET /api/sellers/{slug}/feedback` | web, buyer agents | none | public seller reputation |
+| `POST /api/orders/{id}/feedback` | buyers | BetterAuth session | anonymous session allowed when the order is still owned by the anonymous user |
+| `POST /api/orders`, `POST /api/orders/{id}/payment-intents` | buyers | BetterAuth session | anonymous session allowed |
+| `GET /api/orders`, `GET /api/orders/{id}` | buyers | BetterAuth session | only own orders |
+| `/api/seller/*` browser usage | seller humans | BetterAuth session + active organization | seller context required |
+| `/api/seller/*` agent usage | seller agents | BetterAuth API key | key resolves seller context |
+| internal provider callbacks | Stripe, BTCPay Server, NEAR Intents | provider secret/signature | not public contract |
+
+## URL And Envelope Conventions
+
+### Path conventions
+
+- all marketplace endpoints live under `/api/`
+- public contract is unversioned for now
+- seller-only operations live under `/api/seller/`
+- collection names are plural resource nouns
+- state transitions use subordinate action endpoints when a pure PATCH would obscure workflow meaning
+
+Examples:
+
+- `/api/listings`
+- `/api/listings/{listing_id}`
+- `/api/orders/{order_id}`
+- `/api/seller/listings/{listing_id}/publish`
+
+### Media type
+
+- request and response bodies use `application/json`
+- direct asset uploads use presigned S3-compatible upload URLs and headers for DigitalOcean Spaces, not CMD Market JSON bodies
+
+### Timestamps
+
+- all timestamps are ISO-8601 UTC strings
+
+### IDs
+
+- all resource IDs are opaque strings
+- clients must not infer resource type or chronology from an ID
+
+### Single-resource envelope
+
+```json
+{
+  "data": {
+    "id": "lst_01JQEXAMPLE",
+    "object": "listing"
+  }
+}
+```
+
+### List envelope
+
+```json
+{
+  "data": [
+    {
+      "id": "lst_01JQEXAMPLE",
+      "object": "listing"
+    }
+  ],
+  "page": {
+    "next_cursor": "eyJzb3J0IjoicHVibGlzaGVkX2F0IiwiZCI6IjIwMjYtMDMtMjVUMTI6MDA6MDBaIiwiaWQiOiJsc3RfMDFKUUVYQU1QTEUifQ",
+    "has_more": true
+  }
+}
+```
+
+### Error envelope
+
+Use Problem Details-style errors with a stable machine code and optional field errors.
+
+```json
+{
+  "type": "https://cmd.market/problems/listing-validation-failed",
+  "title": "Listing validation failed",
+  "status": 422,
+  "code": "listing_validation_failed",
+  "detail": "The listing cannot be published until required category fields are complete.",
+  "instance": "/api/seller/listings/lst_01JQEXAMPLE/publish",
+  "errors": [
+    {
+      "field": "attributes.grade",
+      "code": "required",
+      "message": "Grade is required for this category."
+    }
+  ]
+}
+```
+
+## Canonical Resource Shapes
+
+### Listing resource
+
+The listing resource is the core public marketplace object. Public discovery and buyer agents should read the same canonical shape.
+
+Base shape:
+
+```json
+{
+  "id": "lst_01JQEXAMPLE",
+  "object": "listing",
+  "status": "published",
+  "title": "1999 Charizard Holo PSA 8",
+  "description": "Clean slab, no cracks, centered well.",
+  "condition_code": "used_good",
+  "quantity_available": 1,
+  "price": {
+    "amount_minor": 125000,
+    "currency_code": "USD"
+  },
+  "category": {
+    "id": "cat_cards",
+    "slug": "trading-cards",
+    "name": "Trading Cards"
+  },
+  "seller": {
+    "id": "sel_01JQSELLER",
+    "slug": "scarce-cards",
+    "display_name": "Scarce Cards"
+  },
+  "media": [
+    {
+      "id": "med_01JQMEDIA",
+      "url": "https://cdn.cmd.market/listings/lst_01JQEXAMPLE/front.jpg",
+      "alt_text": "Front of PSA slab",
+      "sort_order": 0
+    }
+  ],
+  "attributes": [
+    {
+      "key": "grading_company",
+      "label": "Grading Company",
+      "value_type": "enum",
+      "value": "psa"
+    },
+    {
+      "key": "grade",
+      "label": "Grade",
+      "value_type": "number",
+      "value": 8
+    }
+  ],
+  "published_at": "2026-03-25T14:00:00Z",
+  "updated_at": "2026-03-25T14:05:00Z"
+}
+```
+
+Seller routes may append a `management` object:
+
+```json
+{
+  "management": {
+    "draft_validation": {
+      "publishable": false,
+      "issues": [
+        {
+          "field": "media",
+          "code": "minimum_items_not_met",
+          "message": "At least one image is required."
+        }
+      ]
+    },
+    "created_by": {
+      "actor_type": "api_key",
+      "actor_id": "key_01JQKEY"
+    },
+    "eligibility": {
+      "listing_eligibility_status": "eligible",
+      "listing_eligibility_source": "x_verification"
+    }
+  }
+}
+```
+
+### Seller resource
+
+Public seller/stores should be exposed as `seller` resources rather than leaking internal `seller_account` naming.
+
+```json
+{
+  "id": "sel_01JQSELLER",
+  "object": "seller",
+  "slug": "scarce-cards",
+  "display_name": "Scarce Cards",
+  "bio": "Pokemon and sports cards.",
+  "avatar_url": "https://cdn.cmd.market/sellers/scarce-cards/avatar.jpg",
+  "ratings": {
+    "average": 4.9,
+    "count": 184
+  }
+}
+```
+
+### Seller feedback resource
+
+```json
+{
+  "id": "sfb_01JQFEEDBACK",
+  "object": "seller_feedback",
+  "order_id": "ord_01JQORDER",
+  "rating": 5,
+  "comment": "Fast shipping and exactly as described.",
+  "created_at": "2026-03-25T18:10:00Z"
+}
+```
+
+### Order resource
+
+Orders are buyer-owned in the public surface and seller-owned in the seller surface. Both routes should return the same core order shape.
+
+```json
+{
+  "id": "ord_01JQORDER",
+  "object": "order",
+  "status": "pending_payment",
+  "buyer_kind": "anonymous",
+  "seller": {
+    "id": "sel_01JQSELLER",
+    "slug": "scarce-cards",
+    "display_name": "Scarce Cards"
+  },
+  "items": [
+    {
+      "id": "ori_01JQITEM",
+      "listing_id": "lst_01JQEXAMPLE",
+      "title_snapshot": "1999 Charizard Holo PSA 8",
+      "quantity": 1,
+      "unit_price_minor": 125000,
+      "currency_code": "USD"
+    }
+  ],
+  "totals": {
+    "subtotal_minor": 125000,
+    "shipping_minor": 1500,
+    "platform_fee_minor": 0,
+    "total_minor": 126500,
+    "currency_code": "USD"
+  },
+  "payment_status": "pending",
+  "shipment_status": "pending",
+  "created_at": "2026-03-25T14:20:00Z",
+  "updated_at": "2026-03-25T14:20:00Z"
+}
+```
+
+### Payment intent resource
+
+```json
+{
+  "id": "pay_01JQPAYMENT",
+  "object": "payment_intent",
+  "order_id": "ord_01JQORDER",
+  "rail": "btcpay",
+  "status": "pending",
+  "display_amount": {
+    "amount_minor": 126500,
+    "currency_code": "USD"
+  },
+  "settlement": {
+    "asset_code": "BTC",
+    "amount_atomic": "182500",
+    "asset_decimals": 8
+  },
+  "client_action": {
+    "type": "redirect",
+    "url": "https://btcpay.example/checkout/xyz"
+  },
+  "expires_at": "2026-03-25T14:35:00Z",
+  "created_at": "2026-03-25T14:20:30Z",
+  "updated_at": "2026-03-25T14:20:30Z"
+}
+```
+
+## Namespace And Resource Inventory
+
+## Public Discovery Resources
+
+### `GET /api/categories`
+
+Purpose:
+
+- list active marketplace categories
+
+Supports:
+
+- cursor pagination if needed later
+- public access
+
+### `GET /api/categories/{category_slug}`
+
+Purpose:
+
+- fetch a category and its public attribute/filter metadata
+
+### `GET /api/listings`
+
+Purpose:
+
+- browse public listings
+
+Supports:
+
+- public access
+- search and filter query params
+- cursor pagination
+- summary listing resources
+
+### `GET /api/listings/{listing_id}`
+
+Purpose:
+
+- fetch a full public listing resource
+
+Supports:
+
+- public access
+- optional related includes
+
+### `GET /api/sellers/{seller_slug}`
+
+Purpose:
+
+- fetch a public seller/store profile
+
+### `GET /api/sellers/{seller_slug}/listings`
+
+Purpose:
+
+- list all public listings for a seller/store
+
+### `GET /api/sellers/{seller_slug}/feedback`
+
+Purpose:
+
+- list public buyer-to-seller feedback for a seller/store
+
+## Buyer Commerce Resources
+
+These routes belong to the public marketplace surface but require a BetterAuth session. Anonymous BetterAuth sessions are valid for checkout.
+
+### `POST /api/orders`
+
+Purpose:
+
+- create an order directly from a listing
+
+Auth:
+
+- BetterAuth session required
+- anonymous session allowed
+
+Request contract:
+
+- `listing_id` is required
+- `quantity` required
+- `shipping_address` required
+- no cart model
+
+### `GET /api/orders`
+
+Purpose:
+
+- list orders for the current buyer session user
+
+Auth:
+
+- BetterAuth session required
+
+### `GET /api/orders/{order_id}`
+
+Purpose:
+
+- fetch a buyer-owned order
+
+Auth:
+
+- BetterAuth session required
+
+Notes:
+
+- if an anonymous buyer later links a real account, CMD Market must preserve access by moving buyer-owned marketplace records during BetterAuth anonymous account-link handling
+
+### `POST /api/orders/{order_id}/feedback`
+
+Purpose:
+
+- create buyer-to-seller feedback for a completed buyer-owned order
+
+Auth:
+
+- BetterAuth session required
+
+Notes:
+
+- anonymous sessions are allowed if the order is still owned by the anonymous BetterAuth user
+- exactly one feedback record may be created per completed order
+
+### `POST /api/orders/{order_id}/payment-intents`
+
+Purpose:
+
+- create a payment intent for a buyer-owned order
+
+Auth:
+
+- BetterAuth session required
+
+Notes:
+
+- async resource creation
+- provider settlement happens outside the request-response cycle
+
+### `GET /api/orders/{order_id}/payment-intents`
+
+Purpose:
+
+- list payment intents for a buyer-owned order
+
+Auth:
+
+- BetterAuth session required
+
+## Seller Resources
+
+Seller routes always operate within the resolved seller context.
+
+Context resolution rules:
+
+- session auth uses the active BetterAuth organization
+- API key auth uses the organization referenced by the key
+- if no active organization exists for a browser seller session, return `409 organization_context_required`
+
+### `POST /api/seller/upload-sessions`
+
+Purpose:
+
+- create direct-to-storage upload sessions for listing media
+
+Auth:
+
+- seller session or seller API key
+
+Notes:
+
+- this endpoint creates presigned S3-compatible upload requests for DigitalOcean Spaces
+- the response returns an `asset_key` that matches the object key persisted in marketplace tables
+
+### `POST /api/seller/listings`
+
+Purpose:
+
+- create a listing draft
+
+Auth:
+
+- seller session or seller API key
+
+Notes:
+
+- returns a draft listing resource
+- no publish occurs here
+
+### `GET /api/seller/listings`
+
+Purpose:
+
+- list all listings owned by the current seller context
+
+Auth:
+
+- seller session or seller API key
+
+### `GET /api/seller/listings/{listing_id}`
+
+Purpose:
+
+- fetch one seller-owned listing with management metadata
+
+Auth:
+
+- seller session or seller API key
+
+### `PATCH /api/seller/listings/{listing_id}`
+
+Purpose:
+
+- update draft or unpublished listing fields
+
+Auth:
+
+- seller session or seller API key
+
+### `POST /api/seller/listings/{listing_id}/media`
+
+Purpose:
+
+- attach already-uploaded assets to a listing
+
+Auth:
+
+- seller session or seller API key
+
+### `POST /api/seller/listings/{listing_id}/publish`
+
+Purpose:
+
+- validate and publish a draft listing
+
+Auth:
+
+- seller session or seller API key
+
+Notes:
+
+- validates seller eligibility
+- seller eligibility may come from verified Twitter/X status or the manual approval override path
+- validates required category attributes
+- validates media requirements
+- returns the updated listing resource or a 422 problem details response
+
+### `POST /api/seller/listings/{listing_id}/unpublish`
+
+Purpose:
+
+- remove a published listing from active discovery without deleting it
+
+Auth:
+
+- seller session or seller API key
+
+### `GET /api/seller/orders`
+
+Purpose:
+
+- list orders belonging to the current seller
+
+Auth:
+
+- seller session or seller API key
+
+### `GET /api/seller/orders/{order_id}`
+
+Purpose:
+
+- fetch one seller-owned order
+
+Auth:
+
+- seller session or seller API key
+
+### `POST /api/seller/orders/{order_id}/shipments`
+
+Purpose:
+
+- create or update shipment details for a seller-owned order
+
+Auth:
+
+- seller session or seller API key
+
+### `GET /api/seller/payouts`
+
+Purpose:
+
+- list payout records for the current seller
+
+Auth:
+
+- seller session or seller API key
+
+## BetterAuth Integration Notes
+
+### Anonymous sessions
+
+Anonymous buyers should use BetterAuth's anonymous plugin. Marketplace endpoints do not need a second guest identity system.
+
+Practical effect:
+
+- a buyer can browse publicly with no session
+- the first mutating buyer action can trigger anonymous sign-in if needed
+- order ownership attaches to the anonymous BetterAuth user
+- when that anonymous user links a real auth method, marketplace-owned buyer resources must be reassigned in BetterAuth's `onLinkAccount` flow because the anonymous user is deleted by default
+
+Minimum migration responsibilities during anonymous account linking:
+
+- transfer buyer-owned orders
+- reassign existing `seller_feedback` rows to the linked non-anonymous user when feedback has already been left
+- preserve access to buyer-owned feedback rights for eligible completed orders
+- preserve access to order history
+- preserve authorization checks for future reads and writes
+
+### Organization-backed seller context
+
+Seller humans should use BetterAuth's active organization feature.
+
+Practical effect:
+
+- the browser user chooses a current seller workspace
+- seller API routes infer seller context from that active organization
+- organization switching belongs to BetterAuth, not marketplace routes
+
+### Seller API key lifecycle
+
+Organization-owned API keys are managed by BetterAuth.
+
+The marketplace API should not duplicate API key creation, rotation, or revocation routes under `/api/seller/*`. Marketplace routes only verify and consume those keys.
+
+## Listing Draft And Publish Workflow
+
+### Step 1: create a draft
+
+Request:
+
+`POST /api/seller/listings`
+
+```json
+{
+  "category_id": "cat_cards",
+  "title": "1999 Charizard Holo PSA 8",
+  "description": "Clean slab, no cracks, centered well.",
+  "condition_code": "used_good",
+  "quantity_available": 1,
+  "price": {
+    "amount_minor": 125000,
+    "currency_code": "USD"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "id": "lst_01JQEXAMPLE",
+    "object": "listing",
+    "status": "draft",
+    "title": "1999 Charizard Holo PSA 8",
+    "category": {
+      "id": "cat_cards",
+      "slug": "trading-cards",
+      "name": "Trading Cards"
+    },
+    "management": {
+      "draft_validation": {
+        "publishable": false,
+        "issues": [
+          {
+            "field": "media",
+            "code": "minimum_items_not_met",
+            "message": "At least one image is required."
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Step 2: request upload sessions
+
+Request:
+
+`POST /api/seller/upload-sessions`
+
+```json
+{
+  "files": [
+    {
+      "filename": "front.jpg",
+      "content_type": "image/jpeg",
+      "size_bytes": 2488331
+    }
+  ]
+}
+```
+
+Response:
+
+```json
+{
+  "data": [
+    {
+      "asset_key": "listings/drafts/lst_01JQEXAMPLE/front.jpg",
+      "upload": {
+        "method": "PUT",
+        "url": "https://cmd-market.nyc3.digitaloceanspaces.com/listings/drafts/lst_01JQEXAMPLE/front.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256",
+        "headers": {
+          "content-type": "image/jpeg"
+        },
+        "expires_at": "2026-03-25T15:00:00Z"
+      }
+    }
+  ]
+}
+```
+
+### Step 3: attach uploaded media
+
+Request:
+
+`POST /api/seller/listings/{listing_id}/media`
+
+```json
+{
+  "media": [
+    {
+      "asset_key": "listings/drafts/lst_01JQEXAMPLE/front.jpg",
+      "alt_text": "Front of PSA slab",
+      "sort_order": 0
+    }
+  ]
+}
+```
+
+### Step 4: update attributes
+
+Request:
+
+`PATCH /api/seller/listings/{listing_id}`
+
+```json
+{
+  "attributes": [
+    {
+      "key": "grading_company",
+      "value": "psa"
+    },
+    {
+      "key": "grade",
+      "value": 8
+    }
+  ]
+}
+```
+
+### Step 5: publish
+
+Request:
+
+`POST /api/seller/listings/{listing_id}/publish`
+
+```json
+{}
+```
+
+Success response:
+
+```json
+{
+  "data": {
+    "id": "lst_01JQEXAMPLE",
+    "object": "listing",
+    "status": "published",
+    "published_at": "2026-03-25T14:00:00Z"
+  }
+}
+```
+
+Validation failure example:
+
+```json
+{
+  "type": "https://cmd.market/problems/listing-validation-failed",
+  "title": "Listing validation failed",
+  "status": 422,
+  "code": "listing_validation_failed",
+  "detail": "The listing cannot be published until required fields are complete.",
+  "errors": [
+    {
+      "field": "attributes.grade",
+      "code": "required",
+      "message": "Grade is required for this category."
+    }
+  ]
+}
+```
+
+## Order And Payment Workflow
+
+### Direct checkout request
+
+There is no cart in v1.
+
+An order is created from a listing.
+
+Request:
+
+`POST /api/orders`
+
+```json
+{
+  "listing_id": "lst_01JQEXAMPLE",
+  "quantity": 1,
+  "shipping_address": {
+    "recipient_name": "Ash Ketchum",
+    "line_1": "123 Pallet Town Rd",
+    "city": "Queens",
+    "region": "NY",
+    "postal_code": "11101",
+    "country_code": "US"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "id": "ord_01JQORDER",
+    "object": "order",
+    "status": "pending_payment",
+    "buyer_kind": "anonymous",
+    "totals": {
+      "subtotal_minor": 125000,
+      "shipping_minor": 1500,
+      "platform_fee_minor": 0,
+      "total_minor": 126500,
+      "currency_code": "USD"
+    }
+  }
+}
+```
+
+### Create a payment intent
+
+Request:
+
+`POST /api/orders/{order_id}/payment-intents`
+
+```json
+{
+  "rail": "stripe"
+}
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "id": "pay_01JQPAYMENT",
+    "object": "payment_intent",
+    "order_id": "ord_01JQORDER",
+    "rail": "stripe",
+    "status": "pending",
+    "client_action": {
+      "type": "payment_element",
+      "client_secret": "pi_01JQSECRET"
+    },
+    "expires_at": "2026-03-25T14:35:00Z"
+  }
+}
+```
+
+### Poll order state
+
+Request:
+
+`GET /api/orders/{order_id}`
+
+Response after provider confirmation:
+
+```json
+{
+  "data": {
+    "id": "ord_01JQORDER",
+    "object": "order",
+    "status": "paid",
+    "payment_status": "confirmed",
+    "shipment_status": "pending",
+    "updated_at": "2026-03-25T14:21:10Z"
+  }
+}
+```
+
+## Search And Filter Grammar
+
+### Primary discovery endpoint
+
+`GET /api/listings`
+
+### Supported query parameters
+
+- `q`
+- `category`
+- `seller`
+- `condition`
+- `min_price`
+- `max_price`
+- `in_stock`
+- `sort`
+- `cursor`
+- `limit`
+- `include`
+- `facet.<attribute_key>`
+
+### Parameter semantics
+
+- `q`: free-text query over indexed listing text
+- `category`: category slug
+- `seller`: seller slug
+- `condition`: one or more condition codes
+- `min_price` and `max_price`: minor-unit price bounds in the default display currency
+- `in_stock`: boolean filter
+- `sort`: supported values such as `published_at_desc`, `price_asc`, `price_desc`
+- `cursor`: opaque pagination cursor
+- `limit`: default `25`, max `100`
+- `include`: comma-separated related objects such as `seller,media,attributes`
+- `facet.<attribute_key>`: category-scoped structured filter
+
+### Multi-value semantics
+
+Use repeated query params for multiple values:
+
+```text
+/api/listings?category=trading-cards&condition=used_good&condition=used_fair
+```
+
+Use repeated facet params for multiple allowed values:
+
+```text
+/api/listings?category=trading-cards&facet.grading_company=psa&facet.grading_company=bgs
+```
+
+### Example search
+
+```text
+/api/listings?category=trading-cards&q=charizard&min_price=100000&max_price=200000&facet.grading_company=psa&sort=published_at_desc&limit=25
+```
+
+## Cursor Pagination Contract
+
+### Rules
+
+- collection endpoints use cursor pagination
+- cursors are opaque and client-pass-through only
+- sort order must be stable for the chosen cursor family
+- clients must not construct or edit cursors
+
+### Response shape
+
+```json
+{
+  "data": [],
+  "page": {
+    "next_cursor": "opaque-cursor",
+    "has_more": true
+  }
+}
+```
+
+### Default limits
+
+- default page size: `25`
+- maximum page size: `100`
+
+## Idempotency Contract
+
+### Header
+
+Critical write endpoints require:
+
+`Idempotency-Key: <opaque-client-generated-key>`
+
+### Required endpoints
+
+- `POST /api/orders`
+- `POST /api/orders/{order_id}/payment-intents`
+- `POST /api/orders/{order_id}/feedback`
+- `POST /api/seller/listings/{listing_id}/publish`
+
+### Semantics
+
+- same idempotency key + same route + same authenticated actor + same body returns the original semantic result
+- same idempotency key + different body returns `409 idempotency_conflict`
+- keys should be retained long enough to cover realistic client retries
+
+### Example error
+
+```json
+{
+  "type": "https://cmd.market/problems/idempotency-conflict",
+  "title": "Idempotency key conflict",
+  "status": 409,
+  "code": "idempotency_conflict",
+  "detail": "This idempotency key was already used with a different request body."
+}
+```
+
+## Authorization Rules
+
+### Public discovery
+
+- public discovery routes do not require auth
+- private or draft listings never appear in public routes
+
+### Buyer routes
+
+- buyer order routes require a BetterAuth session
+- anonymous BetterAuth sessions are allowed
+- buyers can read and mutate only their own buyer-owned resources
+
+### Seller routes
+
+- seller routes require either a seller-scoped BetterAuth API key or a BetterAuth session with active organization context
+- seller routes are automatically scoped to the resolved seller context
+- routes must never accept a seller ID override that broadens access
+
+### Ownership errors
+
+Recommended authorization failures:
+
+- `401 unauthorized` when no valid auth exists
+- `403 forbidden` when auth exists but the actor lacks access
+- `404 not_found` when hiding cross-tenant resource existence is preferable
+- `409 organization_context_required` when a browser seller session lacks active organization context
+
+## API Surface Map
+
+```mermaid
+flowchart TD
+    A["BetterAuth auth surface<br/>/api/auth/*"] --> B["Public marketplace API<br/>/api/categories<br/>/api/listings<br/>/api/sellers<br/>/api/sellers/{slug}/feedback<br/>/api/orders<br/>/api/orders/{id}/feedback"]
+    A --> C["Seller API<br/>/api/seller/upload-sessions<br/>/api/seller/listings<br/>/api/seller/orders<br/>/api/seller/payouts"]
+    B --> D["Public discovery<br/>no auth"]
+    B --> E["Buyer commerce<br/>BetterAuth session or anonymous session"]
+    C --> F["Seller browser flows<br/>session + active organization"]
+    C --> G["Seller agent flows<br/>organization-owned API key"]
+    H["Internal provider callbacks<br/>Stripe / BTCPay / NEAR"] --> B
+    H --> C
+```
+
+## Listing Draft And Publish Flow
+
+```mermaid
+flowchart TD
+    A[Create draft listing] --> B[Request upload sessions]
+    B --> C[Upload assets directly to DigitalOcean Spaces]
+    C --> D[Attach uploaded media to draft]
+    D --> E[PATCH listing fields and attributes]
+    E --> F{Publish requested}
+    F -->|No| E
+    F -->|Yes| G[Validate seller eligibility]
+    G --> H[Validate media requirements]
+    H --> I[Validate required category attributes]
+    I --> J{Validation passes}
+    J -->|No| K[Return 422 problem details]
+    J -->|Yes| L[Set listing status to published]
+    L --> M[Return canonical listing resource]
+```
+
+## Async Checkout And Payment Sequence
+
+```mermaid
+sequenceDiagram
+    participant Buyer as Buyer Client
+    participant API as CMD Market API
+    participant Rail as Payment Rail
+    participant Callback as Internal Callback
+
+    Buyer->>API: POST /api/orders
+    API-->>Buyer: 201 order (pending_payment)
+    Buyer->>API: POST /api/orders/{id}/payment-intents
+    API->>Rail: create provider-side payment session
+    API-->>Buyer: 201 payment_intent (pending + client_action)
+    Buyer->>Rail: complete external payment action
+    Rail->>Callback: provider callback / signed event
+    Callback->>API: update payment_intent and order state
+    Buyer->>API: GET /api/orders/{id}
+    API-->>Buyer: order status paid
+    Buyer->>API: GET /api/orders/{id}
+    API-->>Buyer: order status shipped / delivered / completed
+```
+
+## Validation Scenarios
+
+Future implementation should be considered correct only if the API contract supports these scenarios cleanly:
+
+1. Public listing search works without authentication.
+2. Buyer mutations require a BetterAuth session, but anonymous BetterAuth users can still place orders.
+3. Linking an anonymous BetterAuth user to a full account preserves order ownership and history through explicit account-link migration.
+4. Seller browser sessions cannot use seller routes without active organization context.
+5. Seller API keys cannot act outside the organization and seller account they belong to.
+6. Draft listing creation, media upload session creation, asset attach, and publish validation are separate explicit steps.
+7. Order creation, payment intent creation, and payment confirmation work as async state transitions rather than synchronous RPC assumptions.
+8. Clients can fully observe payment, shipment, and completion state through polling without outbound client webhooks.
+9. Search and list endpoints follow one cursor-pagination contract and one canonical listing resource shape.
+10. Seller eligibility checks accept either verified Twitter/X reputation or the manual approval override path.
+11. Only buyers with completed orders can create one feedback record per order, and seller resources can expose aggregate rating data safely.
+
+## Deferred Scope
+
+Explicitly not part of this API design:
+
+- GraphQL
+- RPC-style action API as the primary contract
+- separate backend service boundary
+- admin or backoffice API
+- outbound client webhooks
+- cart API
+- buyer-seller messaging API
+- auction endpoints
+- separate agent-only listing representation
+- formal `/v1` URL prefix
+
+## References
+
+- BetterAuth Database: https://better-auth.com/docs/concepts/database
+- BetterAuth Session Management: https://www.better-auth.com/docs/concepts/session-management
+- BetterAuth Organization plugin: https://www.better-auth.com/docs/plugins/organization
+- BetterAuth API Key plugin: https://www.better-auth.com/docs/plugins/api-key
+- BetterAuth Anonymous plugin: https://www.better-auth.com/docs/plugins/anonymous
+- Database design companion doc: `docs/plans/active/2026-03-22-marketplace-database-design.md`

--- a/docs/product.md
+++ b/docs/product.md
@@ -2,19 +2,19 @@
 
 ## What CMD Market Is
 
-CMD Market is a peer-to-peer marketplace operated by Scarce City, Inc. Sellers list physical goods through an OpenClaw agent skill, and buyers discover items through both the CMD Market web app and their own OpenClaw agents.
+CMD Market is a peer-to-peer marketplace operated by Scarce City, Inc. Sellers list physical goods through agent integrations such as OpenClaw, and buyers discover and purchase items through both the CMD Market web app and their own agents.
 
 ## Core Users
 
 - Sellers who want a fast path from one image upload to structured marketplace listings
-- Buyers who want agent-friendly discovery across CMD Market listings and broader marketplace inventory
+- Buyers who want agent-friendly discovery and checkout on native CMD Market inventory
 
 ## Product Advantages
 
 - Listings are structured for both traditional web browsing and AI-agent crawling.
-- Seller tooling can generate listings for multiple marketplaces from a single upload.
-- Buyer tooling can aggregate native CMD Market listings with affiliate-linked marketplace results.
-- The OpenClaw skill is valuable even when a user does not transact directly on CMD Market, which can grow both supply and demand over time.
+- Sellers can author and manage inventory through either the web app or agent integrations.
+- Buyers can discover, purchase, and track native CMD Market inventory through the same marketplace contract humans and agents share.
+- Seller trust is anchored in Twitter/X-authenticated reputation, with manual approval available as an override path.
 
 ## Current Repo Scope
 


### PR DESCRIPTION
## Summary

- add the active database and API design docs for CMD Market
- align the repo's product/audience/architecture docs with the clarified product direction
- keep the planning artifacts in sync with the new full-product PRD and slice issues on GitHub

## What Changed

- added the active marketplace database design doc plus extracted Mermaid files
- added the active marketplace API design doc
- removed external-marketplace and offer assumptions from the repo docs and planning docs
- aligned the planning docs on native-only inventory, fixed-price checkout, Twitter/X seller gating plus manual override, Stripe + BTCPay + NEAR, anonymous BetterAuth buyers, and buyer-to-seller ratings

## Companion GitHub Work

- created parent PRD issue #5
- synced slice issues #1 through #4 back to #5 and updated their wording to match the current product direction
- kept GitHub native issue dependencies in place for the slice chain

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `rg -n 'external marketplace|affiliate-linked|aggregate native|cross-market|offers|offer_policy|accepted offer|counteroffer|counteroffers|POST /api/listings/.*/offers|POST /api/seller/offers|GET /api/offers|offer history|buyer order and offer routes' docs ARCHITECTURE.md README.md apps/web/docs/design.md -S`
- `gh issue view 1 --json number,title,body,url`
- `gh issue view 2 --json number,title,body,url`
- `gh issue view 3 --json number,title,body,url`
- `gh issue view 4 --json number,title,body,url`
- `gh issue view 5 --json number,title,body,url`
