### PR TITLE
Add flat domestic shipping profiles

### DIFF
--- a/apps/web/app/api/seller/shipping-profiles/[shippingProfileId]/route.ts
+++ b/apps/web/app/api/seller/shipping-profiles/[shippingProfileId]/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import {
+  createSellerApiErrorResponse,
+  parseOptionalSellerApiRequestBody,
+} from "../../../../../lib/seller/api";
+import { serializeShippingProfileResponse } from "../../../../../lib/shipping-profile/http";
+import {
+  getShippingProfile,
+  parseUpdateShippingProfileInput,
+  updateShippingProfile,
+  updateShippingProfileSchema,
+} from "../../../../../lib/shipping-profile/service";
+
+export async function GET(
+  request: Request,
+  context: {
+    params: Promise<{
+      shippingProfileId: string;
+    }>;
+  },
+) {
+  const { shippingProfileId } = await context.params;
+  const result = await getShippingProfile(request, shippingProfileId);
+
+  if (!result.ok) {
+    return createSellerApiErrorResponse(result);
+  }
+
+  return NextResponse.json(serializeShippingProfileResponse(result.data));
+}
+
+export async function PATCH(
+  request: Request,
+  context: {
+    params: Promise<{
+      shippingProfileId: string;
+    }>;
+  },
+) {
+  const parsedBody = await parseOptionalSellerApiRequestBody(
+    request,
+    updateShippingProfileSchema,
+    "Shipping profile update body is invalid.",
+    {},
+  );
+
+  if (!parsedBody.ok) {
+    return parsedBody.response;
+  }
+
+  const { shippingProfileId } = await context.params;
+  const result = await updateShippingProfile(
+    request,
+    shippingProfileId,
+    parseUpdateShippingProfileInput(parsedBody.data),
+  );
+
+  if (!result.ok) {
+    return createSellerApiErrorResponse(result);
+  }
+
+  return NextResponse.json(serializeShippingProfileResponse(result.data));
+}

--- a/apps/web/app/api/seller/shipping-profiles/route.ts
+++ b/apps/web/app/api/seller/shipping-profiles/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import {
+  createSellerApiErrorResponse,
+  parseSellerApiRequestBody,
+} from "../../../../lib/seller/api";
+import {
+  serializeShippingProfileListResponse,
+  serializeShippingProfileResponse,
+} from "../../../../lib/shipping-profile/http";
+import {
+  createShippingProfile,
+  createShippingProfileSchema,
+  listShippingProfiles,
+  parseCreateShippingProfileInput,
+} from "../../../../lib/shipping-profile/service";
+
+export async function GET(request: Request) {
+  const result = await listShippingProfiles(request);
+
+  if (!result.ok) {
+    return createSellerApiErrorResponse(result);
+  }
+
+  return NextResponse.json(serializeShippingProfileListResponse(result.data));
+}
+
+export async function POST(request: Request) {
+  const parsedBody = await parseSellerApiRequestBody(
+    request,
+    createShippingProfileSchema,
+    "Shipping profile request body is invalid.",
+  );
+
+  if (!parsedBody.ok) {
+    return parsedBody.response;
+  }
+
+  const result = await createShippingProfile(request, parseCreateShippingProfileInput(parsedBody.data));
+
+  if (!result.ok) {
+    return createSellerApiErrorResponse(result);
+  }
+
+  return NextResponse.json(serializeShippingProfileResponse(result.data));
+}

--- a/apps/web/app/listings/[listingId]/media/[mediaId]/route.test.ts
+++ b/apps/web/app/listings/[listingId]/media/[mediaId]/route.test.ts
@@ -17,7 +17,8 @@ describe("GET /listings/[listingId]/media/[mediaId]", () => {
     getPublishedListingMedia.mockResolvedValue({
       data: {
         altText: "Front photo",
-        assetUrl: "https://cmd-market-space-dev.nyc3.digitaloceanspaces.com/listings/published/lst_123/front.jpg",
+        assetUrl:
+          "https://cmd-market-space-dev.nyc3.digitaloceanspaces.com/listings/published/lst_123/front.jpg?X-Amz-Signature=test",
         id: "med_123",
         listingId: "lst_123",
         sortOrder: 0,
@@ -36,7 +37,7 @@ describe("GET /listings/[listingId]/media/[mediaId]", () => {
     expect(getPublishedListingMedia).toHaveBeenCalledWith("lst_123", "med_123");
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toBe(
-      "https://cmd-market-space-dev.nyc3.digitaloceanspaces.com/listings/published/lst_123/front.jpg",
+      "https://cmd-market-space-dev.nyc3.digitaloceanspaces.com/listings/published/lst_123/front.jpg?X-Amz-Signature=test",
     );
   });
 

--- a/apps/web/lib/discovery/content.ts
+++ b/apps/web/lib/discovery/content.ts
@@ -3,13 +3,14 @@ export const discoverySummary =
 
 export const discoveryNotes = [
   "Use the public site to see how seller setup works and what is live today.",
-  "Current live APIs cover category metadata, seller draft authoring, direct-upload media attachment, publish validation, and public listing reads.",
+  "Current live APIs cover category metadata, seller draft authoring, reusable shipping profiles, direct-upload media attachment, publish validation, and public listing reads.",
   "CMD Market is built to support many agent clients over time, even though OpenClaw is the first implemented browser handoff integration today.",
   "OpenClaw should start CMD Market auth through the short-lived authorization-session handoff, not by scraping a long-lived key from settings.",
   "The OpenClaw authorization-session API now uses a PKCE-style verifier flow for public clients instead of a shared client secret.",
   "Browser `/seller/*` routes require a browser session.",
   "API keys authenticate seller API routes only.",
-  "Seller API keys do not authenticate browser `/seller/*` routes. Browser seller flows still start with sign-in and either first-workspace creation or workspace selection."
+  "Seller API keys do not authenticate browser `/seller/*` routes. Browser seller flows still start with sign-in and either first-workspace creation or workspace selection.",
+  "Sellers manage reusable shipping profiles, and public listings expose normalized flat domestic shipping for the US 50 states + DC."
 ] as const;
 
 export const publicRoutes = [
@@ -88,6 +89,26 @@ export const sellerApiRoutes = [
     title: "GET /api/seller/publishability"
   },
   {
+    description: "List reusable seller-owned shipping profiles for flat domestic shipping.",
+    href: "/api/seller/shipping-profiles",
+    title: "GET /api/seller/shipping-profiles"
+  },
+  {
+    description: "Create a seller-owned flat domestic shipping profile.",
+    href: "/api/seller/shipping-profiles",
+    title: "POST /api/seller/shipping-profiles"
+  },
+  {
+    description: "Read one seller-owned shipping profile.",
+    href: "/api/seller/shipping-profiles/{shippingProfileId}",
+    title: "GET /api/seller/shipping-profiles/{shippingProfileId}"
+  },
+  {
+    description: "Patch one seller-owned shipping profile.",
+    href: "/api/seller/shipping-profiles/{shippingProfileId}",
+    title: "PATCH /api/seller/shipping-profiles/{shippingProfileId}"
+  },
+  {
     description: "Create a seller-owned draft listing with optional initial listing fields.",
     href: "/api/seller/listings",
     title: "POST /api/seller/listings"
@@ -131,7 +152,7 @@ export const publicApiRoutes = [
     title: "GET /api/categories/{categorySlug}"
   },
   {
-    description: "Read the canonical public listing resource after a draft has been published.",
+    description: "Read the canonical public listing resource after a draft has been published, including normalized flat domestic shipping.",
     href: "/api/listings/{listingId}",
     title: "GET /api/listings/{listingId}"
   }
@@ -180,7 +201,7 @@ export const repoDocs = [
   }
 ] as const satisfies RouteLink[];
 
-export const openApiVersion = "0.3.0";
+export const openApiVersion = "0.4.0";
 
 export function rawGitHubUrl(path: string) {
   return `https://raw.githubusercontent.com/AryanJ-NYC/cmd-market/master/${path}`;

--- a/apps/web/lib/discovery/llms.test.ts
+++ b/apps/web/lib/discovery/llms.test.ts
@@ -11,10 +11,14 @@ describe("buildLlmsText", () => {
     expect(llms).toContain("## Public APIs");
     expect(llms).toContain("[POST /api/openclaw/authorization-sessions](/api/openclaw/authorization-sessions)");
     expect(llms).toContain("[GET /api/categories](/api/categories)");
+    expect(llms).toContain("[GET /api/seller/shipping-profiles](/api/seller/shipping-profiles)");
     expect(llms).toContain("[POST /api/seller/listings/{listingId}/publish](/api/seller/listings/{listingId}/publish)");
     expect(llms).toContain("[OpenAPI](/openapi.json)");
     expect(llms).toContain("Browser `/seller/*` routes require a browser session.");
     expect(llms).toContain("API keys authenticate seller API routes only.");
+    expect(llms).toContain("Sellers manage reusable shipping profiles");
+    expect(llms).toContain("US 50 states + DC");
+    expect(llms).toContain("normalized flat domestic shipping");
     expect(llms).toContain(
       "CMD Market is built to support many agent clients"
     );

--- a/apps/web/lib/discovery/openapi.test.ts
+++ b/apps/web/lib/discovery/openapi.test.ts
@@ -18,6 +18,10 @@ describe("buildOpenApiDocument", () => {
     expect(paths["/api/openclaw/authorization-sessions/{sessionId}/redeem"]?.post).toBeDefined();
     expect(paths["/api/seller/context"]?.get).toBeDefined();
     expect(paths["/api/seller/publishability"]?.get).toBeDefined();
+    expect(paths["/api/seller/shipping-profiles"]?.get).toBeDefined();
+    expect(paths["/api/seller/shipping-profiles"]?.post).toBeDefined();
+    expect(paths["/api/seller/shipping-profiles/{shippingProfileId}"]?.get).toBeDefined();
+    expect(paths["/api/seller/shipping-profiles/{shippingProfileId}"]?.patch).toBeDefined();
     expect(paths["/api/seller/listings"]?.post).toBeDefined();
     expect(paths["/api/seller/listings/{listingId}"]?.get).toBeDefined();
     expect(paths["/api/seller/listings/{listingId}"]?.patch).toBeDefined();
@@ -70,6 +74,25 @@ describe("buildOpenApiDocument", () => {
         code_verifier: expect.any(Object)
       },
       required: ["code_verifier"]
+    });
+    expect(document.components?.schemas?.CreateDraftListingRequest).toMatchObject({
+      properties: {
+        shipping_profile_id: expect.any(Object)
+      }
+    });
+    expect(document.components?.schemas?.UpdateDraftListingRequest).toMatchObject({
+      properties: {
+        shipping_profile_id: expect.any(Object)
+      }
+    });
+    expect(document.components?.schemas?.PublicListingResponse).toMatchObject({
+      properties: {
+        data: {
+          properties: {
+            shipping: expect.any(Object)
+          }
+        }
+      }
     });
   });
 });

--- a/apps/web/lib/discovery/openapi.ts
+++ b/apps/web/lib/discovery/openapi.ts
@@ -21,6 +21,14 @@ import {
   uploadSessionsResponseSchema
 } from "../listing/http";
 import {
+  createShippingProfileSchema,
+  updateShippingProfileSchema
+} from "../shipping-profile/service";
+import {
+  shippingProfileListResponseSchema,
+  shippingProfileResponseSchema
+} from "../shipping-profile/http";
+import {
   openClawAuthorizationSessionCreateRequestSchema,
   openClawAuthorizationSessionCreateResponseSchema,
   openClawAuthorizationSessionRedeemResponseSchema,
@@ -53,21 +61,39 @@ const listingIdPathParamsSchema = z.object({
   })
 });
 
+const shippingProfileIdPathParamsSchema = z.object({
+  shippingProfileId: z.string().meta({
+    description: "Shipping profile identifier.",
+    example: "shp_123"
+  })
+});
+
 export function buildOpenApiDocument() {
-  const createOpenClawAuthorizationSessionRoute = findSellerApiRoute("/api/openclaw/authorization-sessions");
-  const openClawAuthorizationSessionStatusRoute = findSellerApiRoute(
-    "/api/openclaw/authorization-sessions/{sessionId}/status"
+  const createOpenClawAuthorizationSessionRoute = findSellerApiRouteByTitle(
+    "POST /api/openclaw/authorization-sessions"
   );
-  const openClawAuthorizationSessionRedeemRoute = findSellerApiRoute(
-    "/api/openclaw/authorization-sessions/{sessionId}/redeem"
+  const openClawAuthorizationSessionStatusRoute = findSellerApiRouteByTitle(
+    "POST /api/openclaw/authorization-sessions/{sessionId}/status"
   );
-  const sellerContextRoute = findSellerApiRoute("/api/seller/context");
-  const sellerPublishabilityRoute = findSellerApiRoute("/api/seller/publishability");
-  const sellerListingsRoute = findSellerApiRoute("/api/seller/listings");
-  const sellerListingRoute = findSellerApiRoute("/api/seller/listings/{listingId}");
-  const sellerUploadSessionsRoute = findSellerApiRoute("/api/seller/upload-sessions");
-  const sellerListingMediaRoute = findSellerApiRoute("/api/seller/listings/{listingId}/media");
-  const sellerListingPublishRoute = findSellerApiRoute("/api/seller/listings/{listingId}/publish");
+  const openClawAuthorizationSessionRedeemRoute = findSellerApiRouteByTitle(
+    "POST /api/openclaw/authorization-sessions/{sessionId}/redeem"
+  );
+  const sellerContextRoute = findSellerApiRouteByTitle("GET /api/seller/context");
+  const sellerPublishabilityRoute = findSellerApiRouteByTitle("GET /api/seller/publishability");
+  const sellerShippingProfilesRoute = findSellerApiRouteByTitle("GET /api/seller/shipping-profiles");
+  const sellerShippingProfilesCreateRoute = findSellerApiRouteByTitle("POST /api/seller/shipping-profiles");
+  const sellerShippingProfileRoute = findSellerApiRouteByTitle(
+    "GET /api/seller/shipping-profiles/{shippingProfileId}"
+  );
+  const sellerShippingProfilePatchRoute = findSellerApiRouteByTitle(
+    "PATCH /api/seller/shipping-profiles/{shippingProfileId}"
+  );
+  const sellerListingsRoute = findSellerApiRouteByTitle("POST /api/seller/listings");
+  const sellerListingRoute = findSellerApiRouteByTitle("GET /api/seller/listings/{listingId}");
+  const sellerListingPatchRoute = findSellerApiRouteByTitle("PATCH /api/seller/listings/{listingId}");
+  const sellerUploadSessionsRoute = findSellerApiRouteByTitle("POST /api/seller/upload-sessions");
+  const sellerListingMediaRoute = findSellerApiRouteByTitle("POST /api/seller/listings/{listingId}/media");
+  const sellerListingPublishRoute = findSellerApiRouteByTitle("POST /api/seller/listings/{listingId}/publish");
 
   return createDocument({
     components: {
@@ -261,7 +287,7 @@ export function buildOpenApiDocument() {
               "404": errorResponse("Draft listing could not be found.")
             },
             success: {
-              description: sellerListingRoute.description,
+              description: sellerListingPatchRoute.description,
               schema: sellerListingResponseSchema
             }
           }),
@@ -344,6 +370,79 @@ export function buildOpenApiDocument() {
           },
           security: [{ browserSession: [] }, { sellerApiKey: [] }],
           summary: "Publish a draft listing"
+        }
+      },
+      "/api/seller/shipping-profiles": {
+        get: {
+          description:
+            "Lists seller-owned flat domestic shipping profiles. API keys do not authenticate browser `/seller/*` routes.",
+          responses: sellerResponses({
+            success: {
+              description: sellerShippingProfilesRoute.description,
+              schema: shippingProfileListResponseSchema
+            }
+          }),
+          security: [{ browserSession: [] }, { sellerApiKey: [] }],
+          summary: "List shipping profiles"
+        },
+        post: {
+          description:
+            "Creates a seller-owned flat domestic shipping profile. API keys do not authenticate browser `/seller/*` routes.",
+          requestBody: jsonRequestBody(
+            createShippingProfileSchema,
+            "Seller-owned flat domestic shipping profile request payload.",
+            true
+          ),
+          responses: sellerResponses({
+            success: {
+              description: sellerShippingProfilesCreateRoute.description,
+              schema: shippingProfileResponseSchema
+            }
+          }),
+          security: [{ browserSession: [] }, { sellerApiKey: [] }],
+          summary: "Create a shipping profile"
+        }
+      },
+      "/api/seller/shipping-profiles/{shippingProfileId}": {
+        get: {
+          description:
+            "Reads one seller-owned flat domestic shipping profile. API keys do not authenticate browser `/seller/*` routes.",
+          requestParams: {
+            path: shippingProfileIdPathParamsSchema
+          },
+          responses: sellerResponses({
+            additional: {
+              "404": errorResponse("Shipping profile could not be found.")
+            },
+            success: {
+              description: sellerShippingProfileRoute.description,
+              schema: shippingProfileResponseSchema
+            }
+          }),
+          security: [{ browserSession: [] }, { sellerApiKey: [] }],
+          summary: "Read a shipping profile"
+        },
+        patch: {
+          description:
+            "Patches one seller-owned flat domestic shipping profile. API keys do not authenticate browser `/seller/*` routes.",
+          requestBody: jsonRequestBody(
+            updateShippingProfileSchema,
+            "Seller-owned flat domestic shipping profile patch payload."
+          ),
+          requestParams: {
+            path: shippingProfileIdPathParamsSchema
+          },
+          responses: sellerResponses({
+            additional: {
+              "404": errorResponse("Shipping profile could not be found.")
+            },
+            success: {
+              description: sellerShippingProfilePatchRoute.description,
+              schema: shippingProfileResponseSchema
+            }
+          }),
+          security: [{ browserSession: [] }, { sellerApiKey: [] }],
+          summary: "Patch a shipping profile"
         }
       },
       "/api/seller/publishability": {
@@ -465,11 +564,11 @@ function errorResponse(description: string) {
   };
 }
 
-function findSellerApiRoute(href: string) {
-  const route = sellerApiRoutes.find((item) => item.href === href);
+function findSellerApiRouteByTitle(title: string) {
+  const route = sellerApiRoutes.find((item) => item.title === title);
 
   if (!route) {
-    throw new Error(`Missing seller API route: ${href}`);
+    throw new Error(`Missing seller API route: ${title}`);
   }
 
   return route;

--- a/apps/web/lib/listing/domain.test.ts
+++ b/apps/web/lib/listing/domain.test.ts
@@ -50,6 +50,7 @@ describe("listing domain", () => {
           },
         ],
         quantityAvailable: 1,
+        shippingProfileId: "shp_123",
         title: "1999 Charizard Holo PSA 8",
         unitPriceMinor: 125000,
       }),
@@ -89,6 +90,71 @@ describe("listing domain", () => {
       type: "https://cmd.market/problems/listing-validation-failed",
     });
   });
+
+  it("marks drafts without a shipping profile as not publishable", () => {
+    const result = getDraftListingValidation({
+      eligibilityStatus: "eligible",
+      listing: createDraftListingRecord({
+        attributes: [
+          {
+            key: "grading_company",
+            label: "Grading Company",
+            value: "psa",
+            valueType: "enum",
+          },
+          {
+            key: "grade",
+            label: "Grade",
+            value: 8,
+            valueType: "number",
+          },
+        ],
+        category: {
+          attributes: [
+            {
+              isRequired: true,
+              key: "grading_company",
+              label: "Grading Company",
+            },
+            {
+              isRequired: true,
+              key: "grade",
+              label: "Grade",
+            },
+          ],
+          id: "cat_cards",
+          name: "Trading Cards",
+          slug: "trading-cards",
+        },
+        conditionCode: "used_good",
+        description: "Clean slab, no cracks, centered well.",
+        media: [
+          {
+            altText: "Front of slab",
+            assetKey: "listings/drafts/lst_123/front.jpg",
+            assetType: "image",
+            createdAt: new Date("2026-03-30T10:00:00.000Z"),
+            id: "med_123",
+            sortOrder: 0,
+          },
+        ],
+        quantityAvailable: 1,
+        title: "1999 Charizard Holo PSA 8",
+        unitPriceMinor: 125000,
+      }),
+    });
+
+    expect(result).toEqual({
+      issues: [
+        {
+          code: "required",
+          field: "shipping_profile",
+          message: "Shipping profile is required.",
+        },
+      ],
+      publishable: false,
+    });
+  });
 });
 
 function createDraftListingRecord(
@@ -120,6 +186,7 @@ function createDraftListingRecord(
       sortOrder: number;
     }>;
     quantityAvailable: number | null;
+    shippingProfileId: string | null;
     title: string | null;
     unitPriceMinor: number | null;
   }> = {},
@@ -131,6 +198,7 @@ function createDraftListingRecord(
     description: null,
     media: [],
     quantityAvailable: null,
+    shippingProfileId: null,
     title: null,
     unitPriceMinor: null,
     ...overrides,

--- a/apps/web/lib/listing/domain.ts
+++ b/apps/web/lib/listing/domain.ts
@@ -80,6 +80,14 @@ export function getDraftListingValidation({
     });
   }
 
+  if (listing.shippingProfileId == null) {
+    issues.push({
+      code: "required",
+      field: "shipping_profile",
+      message: "Shipping profile is required."
+    });
+  }
+
   if (listing.category) {
     const attributeKeys = new Set(listing.attributes.map((attribute) => attribute.key));
 
@@ -154,6 +162,7 @@ type DraftListingValidationInput = {
     sortOrder: number;
   }>;
   quantityAvailable: number | null;
+  shippingProfileId: string | null;
   title: string | null;
   unitPriceMinor: number | null;
 };

--- a/apps/web/lib/listing/http.test.ts
+++ b/apps/web/lib/listing/http.test.ts
@@ -54,6 +54,14 @@ describe("listing/http", () => {
       },
       publishedAt: null,
       quantityAvailable: 1,
+      shipping: {
+        currencyCode: "USD",
+        domesticRateMinor: 499,
+        handlingTimeDays: 2,
+        mode: "flat",
+        scope: "us_50_states"
+      },
+      shippingProfileId: "shp_123",
       seller: {
         displayName: "Scarce City",
         id: "sel_123",
@@ -93,6 +101,13 @@ describe("listing/http", () => {
       },
       publishedAt: "2026-03-30T20:00:00.000Z",
       quantityAvailable: 1,
+      shipping: {
+        currencyCode: "USD",
+        domesticRateMinor: 499,
+        handlingTimeDays: 2,
+        mode: "flat",
+        scope: "us_50_states"
+      },
       seller: {
         displayName: "Scarce City",
         id: "sel_123",

--- a/apps/web/lib/listing/http.ts
+++ b/apps/web/lib/listing/http.ts
@@ -155,7 +155,7 @@ export const publicListingResponseSchema = z
       price: listingPriceSchema.nullable(),
       published_at: z.string().nullable(),
       quantity_available: z.number().int().nullable(),
-      shipping: listingShippingSchema.nullable(),
+      shipping: listingShippingSchema,
       seller: listingSellerSchema,
       status: z.string(),
       title: z.string().nullable(),

--- a/apps/web/lib/listing/http.ts
+++ b/apps/web/lib/listing/http.ts
@@ -49,6 +49,19 @@ const listingPriceSchema = z
     id: "ListingPrice",
   });
 
+const listingShippingSchema = z
+  .object({
+    currency_code: z.literal("USD"),
+    domestic_rate_minor: z.number().int().nonnegative(),
+    handling_time_days: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+    mode: z.literal("flat"),
+    scope: z.literal("us_50_states"),
+  })
+  .meta({
+    description: "Normalized flat domestic shipping summary.",
+    id: "ListingShipping",
+  });
+
 const listingSellerSchema = z
   .object({
     display_name: z.string(),
@@ -116,6 +129,8 @@ export const sellerListingResponseSchema = z
       price: listingPriceSchema.nullable(),
       published_at: z.string().nullable(),
       quantity_available: z.number().int().nullable(),
+      shipping: listingShippingSchema.nullable(),
+      shipping_profile_id: z.string().nullable(),
       seller: listingSellerSchema,
       status: z.string(),
       title: z.string().nullable(),
@@ -140,6 +155,7 @@ export const publicListingResponseSchema = z
       price: listingPriceSchema.nullable(),
       published_at: z.string().nullable(),
       quantity_available: z.number().int().nullable(),
+      shipping: listingShippingSchema.nullable(),
       seller: listingSellerSchema,
       status: z.string(),
       title: z.string().nullable(),
@@ -281,6 +297,16 @@ export function serializeSellerListingResponse(listing: SellerListingResource) {
         : null,
       published_at: listing.publishedAt,
       quantity_available: listing.quantityAvailable,
+      shipping: listing.shipping
+        ? {
+            currency_code: listing.shipping.currencyCode,
+            domestic_rate_minor: listing.shipping.domesticRateMinor,
+            handling_time_days: listing.shipping.handlingTimeDays,
+            mode: listing.shipping.mode,
+            scope: listing.shipping.scope,
+          }
+        : null,
+      shipping_profile_id: listing.shippingProfileId,
       seller: {
         display_name: listing.seller.displayName,
         id: listing.seller.id,
@@ -327,6 +353,15 @@ export function serializePublicListingResponse(listing: PublicListingResource) {
         : null,
       published_at: listing.publishedAt,
       quantity_available: listing.quantityAvailable,
+      shipping: listing.shipping
+        ? {
+            currency_code: listing.shipping.currencyCode,
+            domestic_rate_minor: listing.shipping.domesticRateMinor,
+            handling_time_days: listing.shipping.handlingTimeDays,
+            mode: listing.shipping.mode,
+            scope: listing.shipping.scope,
+          }
+        : null,
       seller: {
         display_name: listing.seller.displayName,
         id: listing.seller.id,

--- a/apps/web/lib/listing/repository.ts
+++ b/apps/web/lib/listing/repository.ts
@@ -31,6 +31,7 @@ export class PrismaListingRepository implements ListingRepository {
           id: input.id,
           quantityAvailable: input.quantityAvailable,
           sellerAccountId: input.sellerAccountId,
+          shippingProfileId: input.shippingProfileId,
           status: "draft",
           title: input.title,
           unitPriceMinor: input.unitPriceMinor,
@@ -53,6 +54,7 @@ export class PrismaListingRepository implements ListingRepository {
           id: input.auditEventId,
           metadata: {
             categoryId: input.categoryId ?? null,
+            shippingProfileId: input.shippingProfileId ?? null,
             status: "draft",
           } as Prisma.InputJsonValue,
           note: null,
@@ -160,6 +162,7 @@ export class PrismaListingRepository implements ListingRepository {
           description: input.description,
           displayCurrencyCode: input.displayCurrencyCode,
           quantityAvailable: input.quantityAvailable,
+          shippingProfileId: input.shippingProfileId,
           title: input.title,
           unitPriceMinor: input.unitPriceMinor,
           updatedAt: input.updatedAt,
@@ -232,6 +235,7 @@ export class PrismaListingRepository implements ListingRepository {
           metadata: {
             attributeKeys: input.attributes.map((attribute) => attribute.key),
             categoryId: input.categoryId,
+            shippingProfileId: input.shippingProfileId,
           } as Prisma.InputJsonValue,
           note: null,
           sellerAccountId: input.sellerAccountId,
@@ -388,6 +392,7 @@ const listingInclude = {
       sortOrder: "asc",
     },
   },
+  shippingProfile: true,
   sellerAccount: {
     include: {
       organization: true,
@@ -416,6 +421,8 @@ function mapListingModel(record: ListingModel): ListingRecord {
       slug: record.sellerAccount.organization.slug,
     },
     sellerAccountId: record.sellerAccountId,
+    shipping: record.shippingProfile ? mapShippingProfileModel(record.shippingProfile) : null,
+    shippingProfileId: record.shippingProfileId,
     status: record.status,
     title: record.title,
     unitPriceMinor: record.unitPriceMinor,
@@ -454,6 +461,23 @@ function mapListingMediaModel(record: PrismaListingMediaModel): ListingMediaReco
     createdAt: record.createdAt,
     id: record.id,
     sortOrder: record.sortOrder,
+  };
+}
+
+function mapShippingProfileModel(
+  record: {
+    domesticRateMinor: number;
+    handlingTimeDays: number;
+    id: string;
+  },
+): ListingShippingRecord {
+  return {
+    currencyCode: "USD",
+    domesticRateMinor: record.domesticRateMinor,
+    handlingTimeDays: toHandlingTimeDays(record.handlingTimeDays),
+    id: record.id,
+    mode: "flat",
+    scope: "us_50_states",
   };
 }
 
@@ -509,6 +533,14 @@ function toAllowedValues(value: Prisma.JsonValue | null): string[] | null {
   }
 
   return value.every((item) => typeof item === "string") ? value : null;
+}
+
+function toHandlingTimeDays(value: number): 1 | 2 | 3 {
+  if (value === 1 || value === 2 || value === 3) {
+    return value;
+  }
+
+  throw new Error(`Unknown shipping handling time days: ${value}`);
 }
 
 function toNullableJsonValue(value: Prisma.InputJsonValue | null) {
@@ -584,12 +616,23 @@ export type ListingRecord = {
   quantityAvailable: number | null;
   seller: ListingSellerRecord;
   sellerAccountId: string;
+  shipping: ListingShippingRecord | null;
+  shippingProfileId: string | null;
   status: ListingStatus;
   title: string | null;
   unitPriceMinor: number | null;
   updatedAt: Date;
   updatedByApiKeyId: string | null;
   updatedByUserId: string | null;
+};
+
+export type ListingShippingRecord = {
+  currencyCode: "USD";
+  domesticRateMinor: number;
+  handlingTimeDays: 1 | 2 | 3;
+  id: string;
+  mode: "flat";
+  scope: "us_50_states";
 };
 
 export type ListingMediaRecord = {
@@ -644,6 +687,7 @@ type CreateDraftListingInput = {
   id: string;
   quantityAvailable: number | null;
   sellerAccountId: string;
+  shippingProfileId: string | null;
   title: string | null;
   unitPriceMinor: number | null;
   updatedAt: Date;
@@ -690,6 +734,7 @@ type UpdateDraftListingInput = {
   quantityAvailable: number | null;
   removeCategoryAttributeIds: string[];
   sellerAccountId: string;
+  shippingProfileId: string | null;
   title: string | null;
   unitPriceMinor: number | null;
   updatedAt: Date;

--- a/apps/web/lib/listing/service.draft-publish.test.ts
+++ b/apps/web/lib/listing/service.draft-publish.test.ts
@@ -22,6 +22,7 @@ const {
     findShippingProfileById: vi.fn()
   },
   storage: {
+    createPresignedDownloadUrl: vi.fn(),
     getPublicAssetUrl: vi.fn()
   }
 }));
@@ -39,6 +40,7 @@ vi.mock("./repository", () => ({
 }));
 
 vi.mock("../storage/spaces", () => ({
+  createPresignedDownloadUrl: storage.createPresignedDownloadUrl,
   getPublicAssetUrl: storage.getPublicAssetUrl
 }));
 
@@ -69,6 +71,7 @@ describe("listing service issue #3", () => {
     listingRepository.publishDraftListing.mockReset();
     listingRepository.updateDraftListing.mockReset();
     shippingProfileRepository.findShippingProfileById.mockReset();
+    storage.createPresignedDownloadUrl.mockReset();
     storage.getPublicAssetUrl.mockReset();
   });
 
@@ -932,8 +935,8 @@ describe("listing service issue #3", () => {
   });
 
   it("returns the current backing asset url for published listing media", async () => {
-    storage.getPublicAssetUrl.mockReturnValue(
-      "https://cmd-market-space-dev.nyc3.digitaloceanspaces.com/listings/published/lst_123/front.jpg",
+    storage.createPresignedDownloadUrl.mockResolvedValue(
+      "https://cmd-market-space-dev.nyc3.digitaloceanspaces.com/listings/published/lst_123/front.jpg?X-Amz-Signature=test",
     );
     listingRepository.findListingById.mockResolvedValue(
       createListingRecord({
@@ -951,13 +954,16 @@ describe("listing service issue #3", () => {
       data: {
         altText: "Front photo",
         assetUrl:
-          "https://cmd-market-space-dev.nyc3.digitaloceanspaces.com/listings/published/lst_123/front.jpg",
+          "https://cmd-market-space-dev.nyc3.digitaloceanspaces.com/listings/published/lst_123/front.jpg?X-Amz-Signature=test",
         id: "med_123",
         listingId: "lst_123",
         sortOrder: 0,
       },
       ok: true,
     });
+    expect(storage.createPresignedDownloadUrl).toHaveBeenCalledWith(
+      "listings/published/lst_123/front.jpg",
+    );
   });
 
   it("returns not found when published listing media is requested for a missing or draft listing", async () => {

--- a/apps/web/lib/listing/service.draft-publish.test.ts
+++ b/apps/web/lib/listing/service.draft-publish.test.ts
@@ -4,6 +4,7 @@ const {
   createMarketplaceId,
   resolveSellerRequestContext,
   listingRepository,
+  shippingProfileRepository,
   storage
 } = vi.hoisted(() => ({
   createMarketplaceId: vi.fn(),
@@ -16,6 +17,9 @@ const {
     listActiveCategories: vi.fn(),
     publishDraftListing: vi.fn(),
     updateDraftListing: vi.fn()
+  },
+  shippingProfileRepository: {
+    findShippingProfileById: vi.fn()
   },
   storage: {
     getPublicAssetUrl: vi.fn()
@@ -36,6 +40,10 @@ vi.mock("./repository", () => ({
 
 vi.mock("../storage/spaces", () => ({
   getPublicAssetUrl: storage.getPublicAssetUrl
+}));
+
+vi.mock("../shipping-profile/repository", () => ({
+  shippingProfileRepository
 }));
 
 import {
@@ -59,6 +67,7 @@ describe("listing service issue #3", () => {
     listingRepository.listActiveCategories.mockReset();
     listingRepository.publishDraftListing.mockReset();
     listingRepository.updateDraftListing.mockReset();
+    shippingProfileRepository.findShippingProfileById.mockReset();
     storage.getPublicAssetUrl.mockReset();
   });
 
@@ -116,6 +125,11 @@ describe("listing service issue #3", () => {
         },
         {
           code: "required",
+          field: "shipping_profile",
+          message: "Shipping profile is required.",
+        },
+        {
+          code: "required",
           field: "attributes.grading_company",
           message: "Grading Company is required for this category.",
         },
@@ -152,6 +166,61 @@ describe("listing service issue #3", () => {
     });
 
     expect(parsed.success).toBe(false);
+  });
+
+  it("creates a draft listing with a seller-owned shipping profile", async () => {
+    resolveSellerRequestContext.mockResolvedValue(createSellerContext({ eligibilityStatus: "eligible" }));
+    shippingProfileRepository.findShippingProfileById.mockResolvedValue(createShippingProfileRecord());
+    createMarketplaceId.mockReturnValueOnce("lst_123").mockReturnValueOnce("audit_123");
+    listingRepository.createDraftListing.mockResolvedValue(
+      createListingRecord({
+        shipping: createListingShippingRecord(),
+        shippingProfileId: "shp_123",
+      })
+    );
+
+    const result = await createDraftListing(new Request("https://example.com/api/seller/listings", { method: "POST" }), {
+      shippingProfileId: "shp_123",
+    });
+
+    expect(result).toEqual({
+      data: expect.objectContaining({
+        shipping: {
+          currencyCode: "USD",
+          domesticRateMinor: 499,
+          handlingTimeDays: 2,
+          mode: "flat",
+          scope: "us_50_states",
+        },
+        shippingProfileId: "shp_123",
+      }),
+      ok: true,
+    });
+    expect(listingRepository.createDraftListing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shippingProfileId: "shp_123",
+      })
+    );
+  });
+
+  it("rejects using another seller's shipping profile when creating a draft", async () => {
+    resolveSellerRequestContext.mockResolvedValue(createSellerContext());
+    shippingProfileRepository.findShippingProfileById.mockResolvedValue(
+      createShippingProfileRecord({
+        sellerAccountId: "seller_other",
+      })
+    );
+
+    const result = await createDraftListing(new Request("https://example.com/api/seller/listings", { method: "POST" }), {
+      shippingProfileId: "shp_other",
+    });
+
+    expect(result).toEqual({
+      code: "forbidden",
+      message: "Authenticated seller cannot use that shipping profile.",
+      ok: false,
+      status: 403,
+    });
   });
 
   it("rejects draft numeric fields that exceed the postgres integer range", () => {
@@ -255,6 +324,11 @@ describe("listing service issue #3", () => {
           field: "media",
           message: "At least one image is required.",
         },
+        {
+          code: "required",
+          field: "shipping_profile",
+          message: "Shipping profile is required.",
+        },
       ],
       publishable: false,
     });
@@ -281,6 +355,45 @@ describe("listing service issue #3", () => {
           })
         ],
         expectedUpdatedAt: new Date("2026-03-29T20:00:00.000Z"),
+      })
+    );
+  });
+
+  it("updates a draft listing with a seller-owned shipping profile", async () => {
+    resolveSellerRequestContext.mockResolvedValue(createSellerContext({ eligibilityStatus: "eligible" }));
+    listingRepository.findListingById.mockResolvedValue(createListingRecord());
+    shippingProfileRepository.findShippingProfileById.mockResolvedValue(createShippingProfileRecord());
+    listingRepository.updateDraftListing.mockResolvedValue(
+      createListingRecord({
+        shipping: createListingShippingRecord(),
+        shippingProfileId: "shp_123",
+      })
+    );
+
+    const result = await updateDraftListing(
+      new Request("https://example.com/api/seller/listings/lst_123", { method: "PATCH" }),
+      "lst_123",
+      {
+        shippingProfileId: "shp_123",
+      }
+    );
+
+    expect(result).toEqual({
+      data: expect.objectContaining({
+        shipping: {
+          currencyCode: "USD",
+          domesticRateMinor: 499,
+          handlingTimeDays: 2,
+          mode: "flat",
+          scope: "us_50_states",
+        },
+        shippingProfileId: "shp_123",
+      }),
+      ok: true,
+    });
+    expect(listingRepository.updateDraftListing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shippingProfileId: "shp_123",
       })
     );
   });
@@ -505,6 +618,7 @@ describe("listing service issue #3", () => {
         displayCurrencyCode: "USD",
         media: [createListingMediaRecord()],
         quantityAvailable: 1,
+        shippingProfileId: "shp_123",
         title: "1999 Charizard Holo PSA 8",
         unitPriceMinor: 125000
       })
@@ -558,6 +672,7 @@ describe("listing service issue #3", () => {
           description: "Clean slab, no cracks, centered well.",
           media: [createListingMediaRecord()],
           quantityAvailable: 1,
+          shippingProfileId: "shp_123",
           title: "1999 Charizard Holo PSA 8",
           unitPriceMinor: 125000,
         }),
@@ -586,6 +701,7 @@ describe("listing service issue #3", () => {
           media: [createListingMediaRecord()],
           publishedAt: new Date("2026-03-30T20:15:00.000Z"),
           quantityAvailable: 1,
+          shippingProfileId: "shp_123",
           status: "published",
           title: "1999 Charizard Holo PSA 8",
           unitPriceMinor: 125000,
@@ -629,6 +745,7 @@ describe("listing service issue #3", () => {
       description: "Clean slab, no cracks, centered well.",
       media: [createListingMediaRecord()],
       quantityAvailable: 1,
+      shippingProfileId: "shp_123",
       title: "1999 Charizard Holo PSA 8",
       unitPriceMinor: 125000,
       updatedAt: new Date("2026-03-30T20:10:00.000Z"),
@@ -694,6 +811,8 @@ describe("listing service issue #3", () => {
           ],
           publishedAt: new Date("2026-03-30T11:00:00.000Z"),
           quantityAvailable: 1,
+          shipping: createListingShippingRecord(),
+          shippingProfileId: "shp_123",
           status: "published",
           title: "1999 Charizard Holo PSA 8",
           unitPriceMinor: 125000
@@ -727,6 +846,13 @@ describe("listing service issue #3", () => {
     expect(publishedResult.data.price).toEqual({
       amountMinor: 125000,
       currencyCode: "USD",
+    });
+    expect(publishedResult.data.shipping).toEqual({
+      currencyCode: "USD",
+      domesticRateMinor: 499,
+      handlingTimeDays: 2,
+      mode: "flat",
+      scope: "us_50_states",
     });
     expect(publishedResult.data.status).toBe("published");
     expect(publishedResult.data.title).toBe("1999 Charizard Holo PSA 8");
@@ -835,6 +961,14 @@ function createListingRecord(
       slug: string;
     };
     sellerAccountId: string;
+    shipping: {
+      currencyCode: string;
+      domesticRateMinor: number;
+      handlingTimeDays: 1 | 2 | 3;
+      mode: "flat";
+      scope: "us_50_states";
+    } | null;
+    shippingProfileId: string | null;
     status: "draft" | "published";
     title: string | null;
     unitPriceMinor: number | null;
@@ -862,6 +996,8 @@ function createListingRecord(
       slug: "scarce-cards"
     },
     sellerAccountId: "seller_123",
+    shipping: null,
+    shippingProfileId: null,
     status: "draft" as const,
     title: null,
     unitPriceMinor: null,
@@ -909,5 +1045,47 @@ function createListingAttributeRecord(
     value: "psa",
     valueType: "enum" as const,
     ...overrides
+  };
+}
+
+function createShippingProfileRecord(
+  overrides: Partial<{
+    createdAt: Date;
+    domesticRateMinor: number;
+    handlingTimeDays: 1 | 2 | 3;
+    id: string;
+    name: string;
+    sellerAccountId: string;
+    updatedAt: Date;
+  }> = {}
+) {
+  return {
+    createdAt: new Date("2026-04-01T12:00:00.000Z"),
+    domesticRateMinor: 499,
+    handlingTimeDays: 2 as const,
+    id: "shp_123",
+    name: "Card mailer",
+    sellerAccountId: "seller_123",
+    updatedAt: new Date("2026-04-01T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createListingShippingRecord(
+  overrides: Partial<{
+    currencyCode: string;
+    domesticRateMinor: number;
+    handlingTimeDays: 1 | 2 | 3;
+    mode: "flat";
+    scope: "us_50_states";
+  }> = {}
+) {
+  return {
+    currencyCode: "USD",
+    domesticRateMinor: 499,
+    handlingTimeDays: 2 as const,
+    mode: "flat" as const,
+    scope: "us_50_states" as const,
+    ...overrides,
   };
 }

--- a/apps/web/lib/listing/service.draft-publish.test.ts
+++ b/apps/web/lib/listing/service.draft-publish.test.ts
@@ -857,6 +857,24 @@ describe("listing service issue #3", () => {
     expect(publishedResult.data.status).toBe("published");
     expect(publishedResult.data.title).toBe("1999 Charizard Holo PSA 8");
   });
+
+  it("returns not found for published listings that are missing shipping", async () => {
+    listingRepository.findListingById.mockResolvedValue(
+      createListingRecord({
+        publishedAt: new Date("2026-03-30T11:00:00.000Z"),
+        shipping: null,
+        shippingProfileId: null,
+        status: "published",
+      })
+    );
+
+    await expect(getPublicListing("lst_legacy")).resolves.toEqual({
+      code: "listing_not_found",
+      message: "Published listing could not be found.",
+      ok: false,
+      status: 404,
+    });
+  });
 });
 
 function createSellerContext(

--- a/apps/web/lib/listing/service.ts
+++ b/apps/web/lib/listing/service.ts
@@ -6,6 +6,7 @@ import { resolveSellerRequestContext } from "../seller/service";
 import {
   assertUploadedAssetExists,
   buildDraftAssetKey,
+  createPresignedDownloadUrl,
   createPresignedUploadRequest,
   getPublicAssetUrl,
   MissingUploadedAssetError,
@@ -393,7 +394,7 @@ export async function getPublishedListingMedia(
   return {
     data: {
       altText: media.altText,
-      assetUrl: getPublicAssetUrl(media.assetKey),
+      assetUrl: await createPresignedDownloadUrl(media.assetKey),
       id: media.id,
       listingId,
       sortOrder: media.sortOrder,

--- a/apps/web/lib/listing/service.ts
+++ b/apps/web/lib/listing/service.ts
@@ -347,7 +347,7 @@ export async function getPublicListing(
 ): Promise<PublicResult<PublicListingResource>> {
   const listing = await listingRepository.findListingById(listingId);
 
-  if (!listing || listing.status !== "published") {
+  if (!listing || listing.status !== "published" || listing.shipping == null) {
     return {
       code: "listing_not_found",
       message: "Published listing could not be found.",
@@ -789,20 +789,25 @@ function serializePublicListing(listing: ListingRecord): PublicListingResource {
           },
     publishedAt: listing.publishedAt?.toISOString() ?? null,
     quantityAvailable: listing.quantityAvailable,
-    shipping:
-      listing.shipping == null
-        ? null
-        : {
-            currencyCode: listing.shipping.currencyCode,
-            domesticRateMinor: listing.shipping.domesticRateMinor,
-            handlingTimeDays: listing.shipping.handlingTimeDays,
-            mode: listing.shipping.mode,
-            scope: listing.shipping.scope,
-          },
+    shipping: serializeRequiredListingShipping(listing.shipping),
     seller: listing.seller,
     status: listing.status,
     title: listing.title,
     updatedAt: listing.updatedAt.toISOString(),
+  };
+}
+
+function serializeRequiredListingShipping(shipping: ListingRecord["shipping"]) {
+  if (shipping == null) {
+    throw new Error("Published listings must include shipping.");
+  }
+
+  return {
+    currencyCode: shipping.currencyCode,
+    domesticRateMinor: shipping.domesticRateMinor,
+    handlingTimeDays: shipping.handlingTimeDays,
+    mode: shipping.mode,
+    scope: shipping.scope,
   };
 }
 
@@ -1288,6 +1293,13 @@ export type PublicListingResource = BaseListingResource & {
     sortOrder: number;
     url: string;
   }>;
+  shipping: {
+    currencyCode: "USD";
+    domesticRateMinor: number;
+    handlingTimeDays: 1 | 2 | 3;
+    mode: "flat";
+    scope: "us_50_states";
+  };
 };
 
 export type UploadSessionResource = {

--- a/apps/web/lib/listing/service.ts
+++ b/apps/web/lib/listing/service.ts
@@ -16,6 +16,7 @@ import {
   type DraftListingValidationIssue,
   type ListingValidationProblem,
 } from "./domain";
+import { shippingProfileRepository } from "../shipping-profile/repository";
 import {
   DuplicateListingMediaAssetKeyError,
   type CategoryAttributeRecord,
@@ -56,6 +57,20 @@ export async function createDraftListing(
     return categoryResult;
   }
 
+  const shippingProfileResult = input.shippingProfileId
+    ? await getRequiredShippingProfile(
+        input.shippingProfileId,
+        sellerContext.context.sellerAccountId,
+      )
+    : {
+        data: null,
+        ok: true as const,
+      };
+
+  if (!shippingProfileResult.ok) {
+    return shippingProfileResult;
+  }
+
   const now = new Date();
   const listingId = createMarketplaceId();
   const listing = await listingRepository.createDraftListing({
@@ -70,6 +85,7 @@ export async function createDraftListing(
     id: listingId,
     quantityAvailable: input.quantityAvailable ?? null,
     sellerAccountId: sellerContext.context.sellerAccountId,
+    shippingProfileId: shippingProfileResult.data?.id ?? null,
     title: input.title ?? null,
     unitPriceMinor: input.price?.amountMinor ?? null,
     updatedAt: now,
@@ -145,6 +161,28 @@ export async function updateDraftListing(
     return targetCategory;
   }
 
+  const targetShippingProfile = input.shippingProfileId
+    ? await getRequiredShippingProfile(
+        input.shippingProfileId,
+        sellerContext.context.sellerAccountId,
+      )
+    : {
+        data: existingListing.shippingProfileId
+          ? existingListing.shipping
+            ? {
+                id: existingListing.shippingProfileId,
+              }
+            : {
+                id: existingListing.shippingProfileId,
+              }
+          : null,
+        ok: true as const,
+      };
+
+  if (!targetShippingProfile.ok) {
+    return targetShippingProfile;
+  }
+
   const attributeBuild = buildAttributeMutation({
     attributes: input.attributes,
     currentListingAttributes: existingListing.attributes,
@@ -168,6 +206,7 @@ export async function updateDraftListing(
     quantityAvailable: input.quantityAvailable ?? existingListing.quantityAvailable,
     removeCategoryAttributeIds: attributeBuild.data.removeCategoryAttributeIds,
     sellerAccountId: sellerContext.context.sellerAccountId,
+    shippingProfileId: targetShippingProfile.data?.id ?? null,
     title: input.title ?? existingListing.title,
     unitPriceMinor: input.price?.amountMinor ?? existingListing.unitPriceMinor,
     updatedAt: now,
@@ -568,6 +607,10 @@ const draftListingFieldsSchema = z.object({
     description: "Optional available quantity.",
     example: 1,
   }),
+  shipping_profile_id: z.string().trim().min(1).optional().meta({
+    description: "Optional seller-owned shipping profile identifier.",
+    example: "shp_123",
+  }),
   title: z.string().trim().min(1).optional().meta({
     description: "Optional listing title.",
     example: "1999 Charizard Holo PSA 8",
@@ -654,6 +697,7 @@ export function parseDraftListingMutationInput(
         }
       : undefined,
     quantityAvailable: input.quantity_available,
+    shippingProfileId: input.shipping_profile_id,
     title: input.title,
   };
 }
@@ -698,6 +742,17 @@ function serializeSellerListing(
           },
     publishedAt: listing.publishedAt?.toISOString() ?? null,
     quantityAvailable: listing.quantityAvailable,
+    shipping:
+      listing.shipping == null
+        ? null
+        : {
+            currencyCode: listing.shipping.currencyCode,
+            domesticRateMinor: listing.shipping.domesticRateMinor,
+            handlingTimeDays: listing.shipping.handlingTimeDays,
+            mode: listing.shipping.mode,
+            scope: listing.shipping.scope,
+          },
+    shippingProfileId: listing.shippingProfileId,
     seller: listing.seller,
     status: listing.status,
     title: listing.title,
@@ -734,6 +789,16 @@ function serializePublicListing(listing: ListingRecord): PublicListingResource {
           },
     publishedAt: listing.publishedAt?.toISOString() ?? null,
     quantityAvailable: listing.quantityAvailable,
+    shipping:
+      listing.shipping == null
+        ? null
+        : {
+            currencyCode: listing.shipping.currencyCode,
+            domesticRateMinor: listing.shipping.domesticRateMinor,
+            handlingTimeDays: listing.shipping.handlingTimeDays,
+            mode: listing.shipping.mode,
+            scope: listing.shipping.scope,
+          },
     seller: listing.seller,
     status: listing.status,
     title: listing.title,
@@ -792,6 +857,26 @@ function getPublishValidationIssues(
   }
 
   return issues;
+}
+
+async function getRequiredShippingProfile(
+  shippingProfileId: string,
+  sellerAccountId: string,
+) {
+  const shippingProfile = await shippingProfileRepository.findShippingProfileById(shippingProfileId);
+
+  if (!shippingProfile) {
+    return notFound("Shipping profile could not be found.");
+  }
+
+  if (shippingProfile.sellerAccountId !== sellerAccountId) {
+    return forbidden("Authenticated seller cannot use that shipping profile.");
+  }
+
+  return {
+    data: shippingProfile,
+    ok: true as const,
+  };
 }
 
 function buildAttributeMutation({
@@ -1100,6 +1185,7 @@ type DraftListingMutationInput = {
     currencyCode: string;
   };
   quantityAvailable?: number;
+  shippingProfileId?: string;
   title?: string;
 };
 
@@ -1160,6 +1246,13 @@ type BaseListingResource = {
   } | null;
   publishedAt: string | null;
   quantityAvailable: number | null;
+  shipping: {
+    currencyCode: "USD";
+    domesticRateMinor: number;
+    handlingTimeDays: 1 | 2 | 3;
+    mode: "flat";
+    scope: "us_50_states";
+  } | null;
   seller: {
     displayName: string;
     id: string;
@@ -1185,6 +1278,7 @@ export type SellerListingResource = BaseListingResource & {
     sortOrder: number;
     url: string;
   }>;
+  shippingProfileId: string | null;
 };
 
 export type PublicListingResource = BaseListingResource & {

--- a/apps/web/lib/shipping-profile/http.test.ts
+++ b/apps/web/lib/shipping-profile/http.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import {
+  serializeShippingProfileListResponse,
+  serializeShippingProfileResponse,
+  shippingProfileListResponseSchema,
+  shippingProfileResponseSchema,
+} from "./http";
+
+describe("shipping-profile/http", () => {
+  test("serializes shipping profile responses with the shared schema", () => {
+    const response = serializeShippingProfileResponse({
+      createdAt: "2026-04-01T12:00:00.000Z",
+      currencyCode: "USD",
+      domesticRateMinor: 499,
+      handlingTimeDays: 2,
+      id: "shp_123",
+      name: "Card mailer",
+      object: "shipping_profile",
+      scope: "us_50_states",
+      updatedAt: "2026-04-01T12:00:00.000Z",
+    });
+
+    expect(shippingProfileResponseSchema.parse(response)).toEqual(response);
+  });
+
+  test("serializes shipping profile list responses with the shared schema", () => {
+    const response = serializeShippingProfileListResponse([
+      {
+        createdAt: "2026-04-01T12:00:00.000Z",
+        currencyCode: "USD",
+        domesticRateMinor: 499,
+        handlingTimeDays: 2,
+        id: "shp_123",
+        name: "Card mailer",
+        object: "shipping_profile",
+        scope: "us_50_states",
+        updatedAt: "2026-04-01T12:00:00.000Z",
+      },
+    ]);
+
+    expect(shippingProfileListResponseSchema.parse(response)).toEqual(response);
+  });
+});

--- a/apps/web/lib/shipping-profile/http.ts
+++ b/apps/web/lib/shipping-profile/http.ts
@@ -1,0 +1,64 @@
+import "zod-openapi";
+import { z } from "zod";
+import type { ShippingProfileResource } from "./service";
+
+export const shippingProfileSchema = z
+  .object({
+    created_at: z.string(),
+    currency_code: z.literal("USD"),
+    domestic_rate_minor: z.number().int().nonnegative(),
+    handling_time_days: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+    id: z.string(),
+    name: z.string(),
+    object: z.literal("shipping_profile"),
+    scope: z.literal("us_50_states"),
+    updated_at: z.string(),
+  })
+  .meta({
+    description: "Seller-owned flat domestic shipping profile.",
+    id: "ShippingProfile",
+  });
+
+export const shippingProfileResponseSchema = z
+  .object({
+    data: shippingProfileSchema,
+  })
+  .meta({
+    description: "Shipping profile response envelope.",
+    id: "ShippingProfileResponse",
+  });
+
+export const shippingProfileListResponseSchema = z
+  .object({
+    data: z.array(shippingProfileSchema),
+  })
+  .meta({
+    description: "Shipping profile list response envelope.",
+    id: "ShippingProfileListResponse",
+  });
+
+export function serializeShippingProfileResponse(shippingProfile: ShippingProfileResource) {
+  return shippingProfileResponseSchema.parse({
+    data: serializeShippingProfile(shippingProfile),
+  });
+}
+
+export function serializeShippingProfileListResponse(shippingProfiles: ShippingProfileResource[]) {
+  return shippingProfileListResponseSchema.parse({
+    data: shippingProfiles.map(serializeShippingProfile),
+  });
+}
+
+function serializeShippingProfile(shippingProfile: ShippingProfileResource) {
+  return {
+    created_at: shippingProfile.createdAt,
+    currency_code: shippingProfile.currencyCode,
+    domestic_rate_minor: shippingProfile.domesticRateMinor,
+    handling_time_days: shippingProfile.handlingTimeDays,
+    id: shippingProfile.id,
+    name: shippingProfile.name,
+    object: shippingProfile.object,
+    scope: shippingProfile.scope,
+    updated_at: shippingProfile.updatedAt,
+  };
+}

--- a/apps/web/lib/shipping-profile/repository.ts
+++ b/apps/web/lib/shipping-profile/repository.ts
@@ -1,0 +1,136 @@
+import type { PrismaClient, shippingProfile as PrismaShippingProfileModel } from "@prisma/client";
+import { prisma } from "../db/client";
+
+export class PrismaShippingProfileRepository implements ShippingProfileRepository {
+  constructor(private readonly database: PrismaClient) {}
+
+  async createShippingProfile(input: CreateShippingProfileInput): Promise<ShippingProfileRecord> {
+    const created = await this.database.shippingProfile.create({
+      data: {
+        createdAt: input.createdAt,
+        domesticRateMinor: input.domesticRateMinor,
+        handlingTimeDays: input.handlingTimeDays,
+        id: input.id,
+        name: input.name,
+        sellerAccountId: input.sellerAccountId,
+        updatedAt: input.updatedAt,
+      },
+    });
+
+    return mapShippingProfileModel(created);
+  }
+
+  async findShippingProfileById(shippingProfileId: string): Promise<ShippingProfileRecord | null> {
+    const record = await this.database.shippingProfile.findUnique({
+      where: {
+        id: shippingProfileId,
+      },
+    });
+
+    return record ? mapShippingProfileModel(record) : null;
+  }
+
+  async listShippingProfilesBySellerAccountId(sellerAccountId: string): Promise<ShippingProfileRecord[]> {
+    const records = await this.database.shippingProfile.findMany({
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      where: {
+        sellerAccountId,
+      },
+    });
+
+    return records.map(mapShippingProfileModel);
+  }
+
+  async updateShippingProfile(input: UpdateShippingProfileInput): Promise<ShippingProfileRecord | null> {
+    const updateResult = await this.database.shippingProfile.updateMany({
+      data: {
+        domesticRateMinor: input.domesticRateMinor,
+        handlingTimeDays: input.handlingTimeDays,
+        name: input.name,
+        updatedAt: input.updatedAt,
+      },
+      where: {
+        id: input.id,
+        sellerAccountId: input.sellerAccountId,
+        updatedAt: input.expectedUpdatedAt,
+      },
+    });
+
+    if (updateResult.count === 0) {
+      return null;
+    }
+
+    const record = await this.database.shippingProfile.findUnique({
+      where: {
+        id: input.id,
+      },
+    });
+
+    if (!record) {
+      throw new Error(`Missing shipping profile: ${input.id}`);
+    }
+
+    return mapShippingProfileModel(record);
+  }
+}
+
+export const shippingProfileRepository = new PrismaShippingProfileRepository(prisma);
+
+function mapShippingProfileModel(record: PrismaShippingProfileModel): ShippingProfileRecord {
+  return {
+    createdAt: record.createdAt,
+    domesticRateMinor: record.domesticRateMinor,
+    handlingTimeDays: toHandlingTimeDays(record.handlingTimeDays),
+    id: record.id,
+    name: record.name,
+    sellerAccountId: record.sellerAccountId,
+    updatedAt: record.updatedAt,
+  };
+}
+
+function toHandlingTimeDays(value: number): HandlingTimeDays {
+  if (value === 1 || value === 2 || value === 3) {
+    return value;
+  }
+
+  throw new Error(`Unknown shipping handling time days: ${value}`);
+}
+
+export type ShippingProfileRepository = {
+  createShippingProfile(input: CreateShippingProfileInput): Promise<ShippingProfileRecord>;
+  findShippingProfileById(shippingProfileId: string): Promise<ShippingProfileRecord | null>;
+  listShippingProfilesBySellerAccountId(sellerAccountId: string): Promise<ShippingProfileRecord[]>;
+  updateShippingProfile(input: UpdateShippingProfileInput): Promise<ShippingProfileRecord | null>;
+};
+
+export type ShippingProfileRecord = {
+  createdAt: Date;
+  domesticRateMinor: number;
+  handlingTimeDays: HandlingTimeDays;
+  id: string;
+  name: string;
+  sellerAccountId: string;
+  updatedAt: Date;
+};
+
+export type HandlingTimeDays = 1 | 2 | 3;
+
+type CreateShippingProfileInput = {
+  createdAt: Date;
+  domesticRateMinor: number;
+  handlingTimeDays: HandlingTimeDays;
+  id: string;
+  name: string;
+  sellerAccountId: string;
+  updatedAt: Date;
+};
+
+type UpdateShippingProfileInput = {
+  domesticRateMinor: number;
+  expectedUpdatedAt: Date;
+  handlingTimeDays: HandlingTimeDays;
+  id: string;
+  name: string;
+  sellerAccountId: string;
+  updatedAt: Date;
+};

--- a/apps/web/lib/shipping-profile/service.test.ts
+++ b/apps/web/lib/shipping-profile/service.test.ts
@@ -185,6 +185,20 @@ describe("shipping profile service", () => {
         handling_time_days: 4,
       }).success,
     ).toBe(false);
+
+    expect(
+      createShippingProfileSchema.safeParse({
+        domestic_rate_minor: 2_147_483_648,
+        handling_time_days: 2,
+        name: "Too big",
+      }).success,
+    ).toBe(false);
+
+    expect(
+      updateShippingProfileSchema.safeParse({
+        domestic_rate_minor: 2_147_483_648,
+      }).success,
+    ).toBe(false);
   });
 
   it("parses shipping profile inputs into runtime shape", () => {

--- a/apps/web/lib/shipping-profile/service.test.ts
+++ b/apps/web/lib/shipping-profile/service.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createMarketplaceId, resolveSellerRequestContext, shippingProfileRepository } = vi.hoisted(
+  () => ({
+    createMarketplaceId: vi.fn(),
+    resolveSellerRequestContext: vi.fn(),
+    shippingProfileRepository: {
+      createShippingProfile: vi.fn(),
+      findShippingProfileById: vi.fn(),
+      listShippingProfilesBySellerAccountId: vi.fn(),
+      updateShippingProfile: vi.fn(),
+    },
+  }),
+);
+
+vi.mock("../db/ids", () => ({
+  createMarketplaceId,
+}));
+
+vi.mock("../seller/service", () => ({
+  resolveSellerRequestContext,
+}));
+
+vi.mock("./repository", () => ({
+  shippingProfileRepository,
+}));
+
+import {
+  createShippingProfile,
+  createShippingProfileSchema,
+  getShippingProfile,
+  listShippingProfiles,
+  parseCreateShippingProfileInput,
+  parseUpdateShippingProfileInput,
+  updateShippingProfile,
+  updateShippingProfileSchema,
+} from "./service";
+
+describe("shipping profile service", () => {
+  beforeEach(() => {
+    createMarketplaceId.mockReset();
+    resolveSellerRequestContext.mockReset();
+    shippingProfileRepository.createShippingProfile.mockReset();
+    shippingProfileRepository.findShippingProfileById.mockReset();
+    shippingProfileRepository.listShippingProfilesBySellerAccountId.mockReset();
+    shippingProfileRepository.updateShippingProfile.mockReset();
+  });
+
+  it("creates a seller-owned flat domestic shipping profile", async () => {
+    resolveSellerRequestContext.mockResolvedValue(createSellerContext());
+    createMarketplaceId.mockReturnValueOnce("shp_123");
+    shippingProfileRepository.createShippingProfile.mockResolvedValue(createShippingProfileRecord());
+
+    const result = await createShippingProfile(
+      new Request("https://example.com/api/seller/shipping-profiles", { method: "POST" }),
+      {
+        domesticRateMinor: 499,
+        handlingTimeDays: 2,
+        name: "Card mailer",
+      },
+    );
+
+    expect(result).toEqual({
+      data: {
+        createdAt: "2026-04-01T12:00:00.000Z",
+        currencyCode: "USD",
+        domesticRateMinor: 499,
+        handlingTimeDays: 2,
+        id: "shp_123",
+        name: "Card mailer",
+        object: "shipping_profile",
+        scope: "us_50_states",
+        updatedAt: "2026-04-01T12:00:00.000Z",
+      },
+      ok: true,
+    });
+    expect(shippingProfileRepository.createShippingProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domesticRateMinor: 499,
+        handlingTimeDays: 2,
+        id: "shp_123",
+        name: "Card mailer",
+        sellerAccountId: "seller_123",
+      }),
+    );
+  });
+
+  it("lists seller-owned shipping profiles", async () => {
+    resolveSellerRequestContext.mockResolvedValue(createSellerContext());
+    shippingProfileRepository.listShippingProfilesBySellerAccountId.mockResolvedValue([
+      createShippingProfileRecord(),
+    ]);
+
+    const result = await listShippingProfiles(
+      new Request("https://example.com/api/seller/shipping-profiles", { method: "GET" }),
+    );
+
+    expect(result).toEqual({
+      data: [
+        {
+          createdAt: "2026-04-01T12:00:00.000Z",
+          currencyCode: "USD",
+          domesticRateMinor: 499,
+          handlingTimeDays: 2,
+          id: "shp_123",
+          name: "Card mailer",
+          object: "shipping_profile",
+          scope: "us_50_states",
+          updatedAt: "2026-04-01T12:00:00.000Z",
+        },
+      ],
+      ok: true,
+    });
+  });
+
+  it("rejects reading another seller's shipping profile", async () => {
+    resolveSellerRequestContext.mockResolvedValue(createSellerContext());
+    shippingProfileRepository.findShippingProfileById.mockResolvedValue(
+      createShippingProfileRecord({
+        sellerAccountId: "seller_other",
+      }),
+    );
+
+    const result = await getShippingProfile(
+      new Request("https://example.com/api/seller/shipping-profiles/shp_123", { method: "GET" }),
+      "shp_123",
+    );
+
+    expect(result).toEqual({
+      code: "forbidden",
+      message: "Authenticated seller cannot access that shipping profile.",
+      ok: false,
+      status: 403,
+    });
+  });
+
+  it("updates a seller-owned shipping profile", async () => {
+    resolveSellerRequestContext.mockResolvedValue(createSellerContext());
+    shippingProfileRepository.findShippingProfileById.mockResolvedValue(createShippingProfileRecord());
+    shippingProfileRepository.updateShippingProfile.mockResolvedValue(
+      createShippingProfileRecord({
+        domesticRateMinor: 0,
+        handlingTimeDays: 1,
+        name: "Free shipping cards",
+      }),
+    );
+
+    const result = await updateShippingProfile(
+      new Request("https://example.com/api/seller/shipping-profiles/shp_123", { method: "PATCH" }),
+      "shp_123",
+      {
+        domesticRateMinor: 0,
+        handlingTimeDays: 1,
+        name: "Free shipping cards",
+      },
+    );
+
+    expect(result).toEqual({
+      data: {
+        createdAt: "2026-04-01T12:00:00.000Z",
+        currencyCode: "USD",
+        domesticRateMinor: 0,
+        handlingTimeDays: 1,
+        id: "shp_123",
+        name: "Free shipping cards",
+        object: "shipping_profile",
+        scope: "us_50_states",
+        updatedAt: "2026-04-01T12:00:00.000Z",
+      },
+      ok: true,
+    });
+  });
+
+  it("rejects negative rates and unsupported handling windows", () => {
+    expect(
+      createShippingProfileSchema.safeParse({
+        domestic_rate_minor: -1,
+        handling_time_days: 2,
+        name: "Bad profile",
+      }).success,
+    ).toBe(false);
+
+    expect(
+      updateShippingProfileSchema.safeParse({
+        handling_time_days: 4,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("parses shipping profile inputs into runtime shape", () => {
+    const parsed = createShippingProfileSchema.parse({
+      domestic_rate_minor: 499,
+      handling_time_days: 2,
+      name: "Card mailer",
+    });
+
+    expect(parseCreateShippingProfileInput(parsed)).toEqual({
+      domesticRateMinor: 499,
+      handlingTimeDays: 2,
+      name: "Card mailer",
+    });
+
+    const updated = updateShippingProfileSchema.parse({
+      domestic_rate_minor: 0,
+    });
+
+    expect(parseUpdateShippingProfileInput(updated)).toEqual({
+      domesticRateMinor: 0,
+      handlingTimeDays: undefined,
+      name: undefined,
+    });
+  });
+});
+
+function createSellerContext() {
+  return {
+    context: {
+      actorApiKeyId: null,
+      actorType: "user" as const,
+      actorUserId: "user_123",
+      eligibilitySource: null,
+      eligibilityStatus: "eligible" as const,
+      organizationId: "org_123",
+      sellerAccountId: "seller_123",
+    },
+    ok: true as const,
+  };
+}
+
+function createShippingProfileRecord(
+  overrides: Partial<{
+    createdAt: Date;
+    domesticRateMinor: number;
+    handlingTimeDays: 1 | 2 | 3;
+    id: string;
+    name: string;
+    sellerAccountId: string;
+    updatedAt: Date;
+  }> = {},
+) {
+  return {
+    createdAt: new Date("2026-04-01T12:00:00.000Z"),
+    domesticRateMinor: 499,
+    handlingTimeDays: 2 as const,
+    id: "shp_123",
+    name: "Card mailer",
+    sellerAccountId: "seller_123",
+    updatedAt: new Date("2026-04-01T12:00:00.000Z"),
+    ...overrides,
+  };
+}

--- a/apps/web/lib/shipping-profile/service.ts
+++ b/apps/web/lib/shipping-profile/service.ts
@@ -9,6 +9,7 @@ import {
 } from "./repository";
 
 const DOMESTIC_CURRENCY_CODE = "USD";
+const POSTGRES_INTEGER_MAX = 2_147_483_647;
 const SHIPPING_SCOPE = "us_50_states";
 
 export async function createShippingProfile(
@@ -144,10 +145,15 @@ export async function updateShippingProfile(
 
 export const createShippingProfileSchema = z
   .object({
-    domestic_rate_minor: z.number().int().nonnegative().meta({
-      description: "Flat domestic shipping rate in USD minor units.",
-      example: 499,
-    }),
+    domestic_rate_minor: z
+      .number()
+      .int()
+      .nonnegative()
+      .lte(POSTGRES_INTEGER_MAX)
+      .meta({
+        description: "Flat domestic shipping rate in USD minor units.",
+        example: 499,
+      }),
     handling_time_days: z.union([z.literal(1), z.literal(2), z.literal(3)]).meta({
       description: "Estimated seller handling time in business days.",
       example: 2,
@@ -165,10 +171,16 @@ export const createShippingProfileSchema = z
 
 export const updateShippingProfileSchema = z
   .object({
-    domestic_rate_minor: z.number().int().nonnegative().optional().meta({
-      description: "Flat domestic shipping rate in USD minor units.",
-      example: 0,
-    }),
+    domestic_rate_minor: z
+      .number()
+      .int()
+      .nonnegative()
+      .lte(POSTGRES_INTEGER_MAX)
+      .optional()
+      .meta({
+        description: "Flat domestic shipping rate in USD minor units.",
+        example: 0,
+      }),
     handling_time_days: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional().meta({
       description: "Estimated seller handling time in business days.",
       example: 1,

--- a/apps/web/lib/shipping-profile/service.ts
+++ b/apps/web/lib/shipping-profile/service.ts
@@ -1,0 +1,277 @@
+import "zod-openapi";
+import { z } from "zod";
+import { createMarketplaceId } from "../db/ids";
+import { resolveSellerRequestContext } from "../seller/service";
+import {
+  shippingProfileRepository,
+  type HandlingTimeDays,
+  type ShippingProfileRecord,
+} from "./repository";
+
+const DOMESTIC_CURRENCY_CODE = "USD";
+const SHIPPING_SCOPE = "us_50_states";
+
+export async function createShippingProfile(
+  request: Request,
+  input: ShippingProfileMutationInput,
+): Promise<ShippingProfileActionResult<ShippingProfileResource>> {
+  const sellerContext = await resolveSellerRequestContext(request);
+
+  if (!sellerContext.ok) {
+    return sellerContext;
+  }
+
+  const now = new Date();
+  const shippingProfile = await shippingProfileRepository.createShippingProfile({
+    createdAt: now,
+    domesticRateMinor: input.domesticRateMinor,
+    handlingTimeDays: input.handlingTimeDays,
+    id: createMarketplaceId(),
+    name: input.name,
+    sellerAccountId: sellerContext.context.sellerAccountId,
+    updatedAt: now,
+  });
+
+  return {
+    data: serializeShippingProfile(shippingProfile),
+    ok: true,
+  };
+}
+
+export async function listShippingProfiles(
+  request: Request,
+): Promise<ShippingProfileActionResult<ShippingProfileResource[]>> {
+  const sellerContext = await resolveSellerRequestContext(request);
+
+  if (!sellerContext.ok) {
+    return sellerContext;
+  }
+
+  const shippingProfiles = await shippingProfileRepository.listShippingProfilesBySellerAccountId(
+    sellerContext.context.sellerAccountId,
+  );
+
+  return {
+    data: shippingProfiles.map(serializeShippingProfile),
+    ok: true,
+  };
+}
+
+export async function getShippingProfile(
+  request: Request,
+  shippingProfileId: string,
+): Promise<ShippingProfileActionResult<ShippingProfileResource>> {
+  const sellerContext = await resolveSellerRequestContext(request);
+
+  if (!sellerContext.ok) {
+    return sellerContext;
+  }
+
+  const shippingProfile = await shippingProfileRepository.findShippingProfileById(shippingProfileId);
+
+  if (!shippingProfile) {
+    return notFound("Shipping profile could not be found.");
+  }
+
+  if (shippingProfile.sellerAccountId !== sellerContext.context.sellerAccountId) {
+    return forbidden("Authenticated seller cannot access that shipping profile.");
+  }
+
+  return {
+    data: serializeShippingProfile(shippingProfile),
+    ok: true,
+  };
+}
+
+export async function updateShippingProfile(
+  request: Request,
+  shippingProfileId: string,
+  input: Partial<ShippingProfileMutationInput>,
+): Promise<ShippingProfileActionResult<ShippingProfileResource>> {
+  const sellerContext = await resolveSellerRequestContext(request);
+
+  if (!sellerContext.ok) {
+    return sellerContext;
+  }
+
+  const existingShippingProfile = await shippingProfileRepository.findShippingProfileById(
+    shippingProfileId,
+  );
+
+  if (!existingShippingProfile) {
+    return notFound("Shipping profile could not be found.");
+  }
+
+  if (existingShippingProfile.sellerAccountId !== sellerContext.context.sellerAccountId) {
+    return forbidden("Authenticated seller cannot modify that shipping profile.");
+  }
+
+  const now = new Date();
+  const updatedShippingProfile = await shippingProfileRepository.updateShippingProfile({
+    domesticRateMinor: input.domesticRateMinor ?? existingShippingProfile.domesticRateMinor,
+    expectedUpdatedAt: existingShippingProfile.updatedAt,
+    handlingTimeDays: input.handlingTimeDays ?? existingShippingProfile.handlingTimeDays,
+    id: shippingProfileId,
+    name: input.name ?? existingShippingProfile.name,
+    sellerAccountId: sellerContext.context.sellerAccountId,
+    updatedAt: now,
+  });
+
+  if (!updatedShippingProfile) {
+    const latestShippingProfile = await shippingProfileRepository.findShippingProfileById(
+      shippingProfileId,
+    );
+
+    if (!latestShippingProfile) {
+      return notFound("Shipping profile could not be found.");
+    }
+
+    if (latestShippingProfile.sellerAccountId !== sellerContext.context.sellerAccountId) {
+      return forbidden("Authenticated seller cannot modify that shipping profile.");
+    }
+
+    return conflict(
+      "shipping_profile_update_conflict",
+      "Shipping profile could not be updated because it changed during the request.",
+    );
+  }
+
+  return {
+    data: serializeShippingProfile(updatedShippingProfile),
+    ok: true,
+  };
+}
+
+export const createShippingProfileSchema = z
+  .object({
+    domestic_rate_minor: z.number().int().nonnegative().meta({
+      description: "Flat domestic shipping rate in USD minor units.",
+      example: 499,
+    }),
+    handling_time_days: z.union([z.literal(1), z.literal(2), z.literal(3)]).meta({
+      description: "Estimated seller handling time in business days.",
+      example: 2,
+    }),
+    name: z.string().trim().min(1).meta({
+      description: "Human-readable shipping profile name.",
+      example: "Card mailer",
+    }),
+  })
+  .strict()
+  .meta({
+    description: "Payload for creating a seller-owned flat domestic shipping profile.",
+    id: "CreateShippingProfileRequest",
+  });
+
+export const updateShippingProfileSchema = z
+  .object({
+    domestic_rate_minor: z.number().int().nonnegative().optional().meta({
+      description: "Flat domestic shipping rate in USD minor units.",
+      example: 0,
+    }),
+    handling_time_days: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional().meta({
+      description: "Estimated seller handling time in business days.",
+      example: 1,
+    }),
+    name: z.string().trim().min(1).optional().meta({
+      description: "Human-readable shipping profile name.",
+      example: "Free shipping cards",
+    }),
+  })
+  .strict()
+  .meta({
+    description: "Payload for patching a seller-owned shipping profile.",
+    id: "UpdateShippingProfileRequest",
+  });
+
+export function parseCreateShippingProfileInput(
+  input: z.infer<typeof createShippingProfileSchema>,
+): ShippingProfileMutationInput {
+  return {
+    domesticRateMinor: input.domestic_rate_minor,
+    handlingTimeDays: input.handling_time_days,
+    name: input.name,
+  };
+}
+
+export function parseUpdateShippingProfileInput(
+  input: z.infer<typeof updateShippingProfileSchema>,
+): Partial<ShippingProfileMutationInput> {
+  return {
+    domesticRateMinor: input.domestic_rate_minor,
+    handlingTimeDays: input.handling_time_days,
+    name: input.name,
+  };
+}
+
+function serializeShippingProfile(shippingProfile: ShippingProfileRecord): ShippingProfileResource {
+  return {
+    createdAt: shippingProfile.createdAt.toISOString(),
+    currencyCode: DOMESTIC_CURRENCY_CODE,
+    domesticRateMinor: shippingProfile.domesticRateMinor,
+    handlingTimeDays: shippingProfile.handlingTimeDays,
+    id: shippingProfile.id,
+    name: shippingProfile.name,
+    object: "shipping_profile",
+    scope: SHIPPING_SCOPE,
+    updatedAt: shippingProfile.updatedAt.toISOString(),
+  };
+}
+
+function conflict(code: string, message: string): ShippingProfileActionResult<never> {
+  return {
+    code,
+    message,
+    ok: false,
+    status: 409,
+  };
+}
+
+function forbidden(message: string): ShippingProfileActionResult<never> {
+  return {
+    code: "forbidden",
+    message,
+    ok: false,
+    status: 403,
+  };
+}
+
+function notFound(message: string): ShippingProfileActionResult<never> {
+  return {
+    code: "shipping_profile_not_found",
+    message,
+    ok: false,
+    status: 404,
+  };
+}
+
+type ShippingProfileMutationInput = {
+  domesticRateMinor: number;
+  handlingTimeDays: HandlingTimeDays;
+  name: string;
+};
+
+export type ShippingProfileResource = {
+  createdAt: string;
+  currencyCode: "USD";
+  domesticRateMinor: number;
+  handlingTimeDays: HandlingTimeDays;
+  id: string;
+  name: string;
+  object: "shipping_profile";
+  scope: "us_50_states";
+  updatedAt: string;
+};
+
+type ShippingProfileActionResult<T> =
+  | {
+      data: T;
+      ok: true;
+    }
+  | {
+      code: string;
+      message: string;
+      ok: false;
+      retryAfterMs?: number;
+      status: number;
+    };

--- a/apps/web/lib/storage/spaces.ts
+++ b/apps/web/lib/storage/spaces.ts
@@ -1,4 +1,4 @@
-import { HeadObjectCommand, S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { GetObjectCommand, HeadObjectCommand, S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { env } from '../env';
 
@@ -6,6 +6,7 @@ import { env } from '../env';
 const SPACES_REGION = 'nyc3';
 const SPACES_BUCKET = 'cmd-market-space-dev';
 const SPACES_PUBLIC_BASE_URL = `https://${SPACES_BUCKET}.${SPACES_REGION}.digitaloceanspaces.com`;
+const DOWNLOAD_URL_TTL_SECONDS = 60 * 15;
 const UPLOAD_URL_TTL_SECONDS = 60 * 15;
 
 let spacesClient: S3Client | null = null;
@@ -40,6 +41,17 @@ export function buildDraftAssetKey({ filename, listingId, uploadId }: BuildDraft
 
 export function getPublicAssetUrl(assetKey: string) {
   return new URL(assetKey, `${SPACES_PUBLIC_BASE_URL}/`).toString();
+}
+
+export async function createPresignedDownloadUrl(assetKey: string) {
+  const command = new GetObjectCommand({
+    Bucket: SPACES_BUCKET,
+    Key: assetKey,
+  });
+
+  return getSignedUrl(getSpacesClient(), command, {
+    expiresIn: DOWNLOAD_URL_TTL_SECONDS,
+  });
 }
 
 export async function assertUploadedAssetExists(assetKey: string) {

--- a/apps/web/prisma/migrations/20260401185238_issue_shipping_profiles/migration.sql
+++ b/apps/web/prisma/migrations/20260401185238_issue_shipping_profiles/migration.sql
@@ -33,4 +33,4 @@ ALTER TABLE "shipping_profile" ADD CONSTRAINT "shipping_profile_domestic_rate_mi
 ALTER TABLE "shipping_profile" ADD CONSTRAINT "shipping_profile_handling_time_days_valid" CHECK ("handling_time_days" IN (1, 2, 3));
 
 -- AddConstraint
-ALTER TABLE "listing" ADD CONSTRAINT "listing_non_draft_requires_shipping_profile" CHECK ("status" = 'draft' OR "shipping_profile_id" IS NOT NULL);
+ALTER TABLE "listing" ADD CONSTRAINT "listing_non_draft_requires_shipping_profile" CHECK ("status" = 'draft' OR "shipping_profile_id" IS NOT NULL) NOT VALID;

--- a/apps/web/prisma/migrations/20260401185238_issue_shipping_profiles/migration.sql
+++ b/apps/web/prisma/migrations/20260401185238_issue_shipping_profiles/migration.sql
@@ -25,3 +25,12 @@ ALTER TABLE "listing" ADD CONSTRAINT "listing_shipping_profile_id_fkey" FOREIGN 
 
 -- AddForeignKey
 ALTER TABLE "shipping_profile" ADD CONSTRAINT "shipping_profile_seller_account_id_fkey" FOREIGN KEY ("seller_account_id") REFERENCES "seller_account"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddConstraint
+ALTER TABLE "shipping_profile" ADD CONSTRAINT "shipping_profile_domestic_rate_minor_nonnegative" CHECK ("domestic_rate_minor" >= 0);
+
+-- AddConstraint
+ALTER TABLE "shipping_profile" ADD CONSTRAINT "shipping_profile_handling_time_days_valid" CHECK ("handling_time_days" IN (1, 2, 3));
+
+-- AddConstraint
+ALTER TABLE "listing" ADD CONSTRAINT "listing_non_draft_requires_shipping_profile" CHECK ("status" = 'draft' OR "shipping_profile_id" IS NOT NULL);

--- a/apps/web/prisma/migrations/20260401185238_issue_shipping_profiles/migration.sql
+++ b/apps/web/prisma/migrations/20260401185238_issue_shipping_profiles/migration.sql
@@ -1,0 +1,27 @@
+-- AlterTable
+ALTER TABLE "listing" ADD COLUMN     "shipping_profile_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "shipping_profile" (
+    "id" TEXT NOT NULL,
+    "seller_account_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "domestic_rate_minor" INTEGER NOT NULL,
+    "handling_time_days" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "shipping_profile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "shipping_profile_seller_account_id_idx" ON "shipping_profile"("seller_account_id");
+
+-- CreateIndex
+CREATE INDEX "listing_shipping_profile_id_idx" ON "listing"("shipping_profile_id");
+
+-- AddForeignKey
+ALTER TABLE "listing" ADD CONSTRAINT "listing_shipping_profile_id_fkey" FOREIGN KEY ("shipping_profile_id") REFERENCES "shipping_profile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "shipping_profile" ADD CONSTRAINT "shipping_profile_seller_account_id_fkey" FOREIGN KEY ("seller_account_id") REFERENCES "seller_account"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -209,6 +209,7 @@ model sellerAccount {
   updatedAt                  DateTime                @updatedAt @map("updated_at")
   auditEvents                auditEvent[]
   listings                   listing[]
+  shippingProfiles           shippingProfile[]
   organization               organization            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@map("seller_account")
@@ -314,6 +315,7 @@ model auditEvent {
 model listing {
   id                 String                 @id
   sellerAccountId    String                 @map("seller_account_id")
+  shippingProfileId  String?                @map("shipping_profile_id")
   categoryId         String?                @map("category_id")
   title              String?
   description        String?
@@ -336,12 +338,29 @@ model listing {
   createdByUser      user?                  @relation("listingCreatedByUser", fields: [createdByUserId], references: [id], onDelete: SetNull)
   media              listingMedia[]
   sellerAccount      sellerAccount          @relation(fields: [sellerAccountId], references: [id], onDelete: Cascade)
+  shippingProfile    shippingProfile?       @relation(fields: [shippingProfileId], references: [id], onDelete: SetNull)
   updatedByApiKey    apikey?                @relation("listingUpdatedByApiKey", fields: [updatedByApiKeyId], references: [id], onDelete: SetNull)
   updatedByUser      user?                  @relation("listingUpdatedByUser", fields: [updatedByUserId], references: [id], onDelete: SetNull)
 
   @@index([sellerAccountId])
+  @@index([shippingProfileId])
   @@index([categoryId])
   @@map("listing")
+}
+
+model shippingProfile {
+  id                String         @id
+  sellerAccountId   String         @map("seller_account_id")
+  name              String
+  domesticRateMinor Int            @map("domestic_rate_minor")
+  handlingTimeDays  Int            @map("handling_time_days")
+  createdAt         DateTime       @default(now()) @map("created_at")
+  updatedAt         DateTime       @updatedAt @map("updated_at")
+  listings          listing[]
+  sellerAccount     sellerAccount  @relation(fields: [sellerAccountId], references: [id], onDelete: Cascade)
+
+  @@index([sellerAccountId])
+  @@map("shipping_profile")
 }
 
 model listingMedia {

--- a/apps/web/prisma/schema.test.ts
+++ b/apps/web/prisma/schema.test.ts
@@ -88,6 +88,9 @@ describe("prisma seller eligibility schema", () => {
     expect(migration).toContain('CREATE INDEX "shipping_profile_seller_account_id_idx"');
     expect(migration).toContain('CREATE INDEX "listing_shipping_profile_id_idx"');
     expect(migration).toContain('ALTER TABLE "listing" ADD CONSTRAINT "listing_shipping_profile_id_fkey"');
+    expect(migration).toContain('ALTER TABLE "shipping_profile" ADD CONSTRAINT "shipping_profile_domestic_rate_minor_nonnegative"');
+    expect(migration).toContain('ALTER TABLE "shipping_profile" ADD CONSTRAINT "shipping_profile_handling_time_days_valid"');
+    expect(migration).toContain('ALTER TABLE "listing" ADD CONSTRAINT "listing_non_draft_requires_shipping_profile"');
   });
 
   it("defines marketplace category metadata and listing attribute models", () => {

--- a/apps/web/prisma/schema.test.ts
+++ b/apps/web/prisma/schema.test.ts
@@ -90,7 +90,9 @@ describe("prisma seller eligibility schema", () => {
     expect(migration).toContain('ALTER TABLE "listing" ADD CONSTRAINT "listing_shipping_profile_id_fkey"');
     expect(migration).toContain('ALTER TABLE "shipping_profile" ADD CONSTRAINT "shipping_profile_domestic_rate_minor_nonnegative"');
     expect(migration).toContain('ALTER TABLE "shipping_profile" ADD CONSTRAINT "shipping_profile_handling_time_days_valid"');
-    expect(migration).toContain('ALTER TABLE "listing" ADD CONSTRAINT "listing_non_draft_requires_shipping_profile"');
+    expect(migration).toContain(
+      'ALTER TABLE "listing" ADD CONSTRAINT "listing_non_draft_requires_shipping_profile" CHECK ("status" = \'draft\' OR "shipping_profile_id" IS NOT NULL) NOT VALID;'
+    );
   });
 
   it("defines marketplace category metadata and listing attribute models", () => {

--- a/apps/web/prisma/schema.test.ts
+++ b/apps/web/prisma/schema.test.ts
@@ -52,6 +52,20 @@ describe("prisma seller eligibility schema", () => {
     expect(schema).toContain("@unique([listingId, assetKey])");
   });
 
+  it("defines seller-owned shipping profiles and listing shipping references in the schema", () => {
+    const schema = readPrismaFile("schema.prisma");
+
+    expect(schema).toContain("model shippingProfile {");
+    expect(schema).toContain("sellerAccountId");
+    expect(schema).toContain('@map("seller_account_id")');
+    expect(schema).toContain("domesticRateMinor");
+    expect(schema).toContain('@map("domestic_rate_minor")');
+    expect(schema).toContain("handlingTimeDays");
+    expect(schema).toContain('@map("handling_time_days")');
+    expect(schema).toContain("shippingProfileId");
+    expect(schema).toContain('@map("shipping_profile_id")');
+  });
+
   it("creates listing and listing_media tables in the initial migration", () => {
     const migration = readAllMigrationSql();
 
@@ -62,6 +76,18 @@ describe("prisma seller eligibility schema", () => {
     expect(migration).toContain(
       'CREATE UNIQUE INDEX "listing_media_listing_id_asset_key_key" ON "listing_media"("listing_id", "asset_key");'
     );
+  });
+
+  it("creates shipping_profile persistence and listing shipping foreign keys in migrations", () => {
+    const migration = readAllMigrationSql();
+
+    expect(migration).toContain('CREATE TABLE "shipping_profile"');
+    expect(migration).toContain('"seller_account_id" TEXT NOT NULL');
+    expect(migration).toContain('"domestic_rate_minor" INTEGER NOT NULL');
+    expect(migration).toContain('"handling_time_days" INTEGER NOT NULL');
+    expect(migration).toContain('CREATE INDEX "shipping_profile_seller_account_id_idx"');
+    expect(migration).toContain('CREATE INDEX "listing_shipping_profile_id_idx"');
+    expect(migration).toContain('ALTER TABLE "listing" ADD CONSTRAINT "listing_shipping_profile_id_fkey"');
   });
 
   it("defines marketplace category metadata and listing attribute models", () => {

--- a/docs/development.md
+++ b/docs/development.md
@@ -58,6 +58,10 @@
   - `POST /api/openclaw/authorization-sessions/:sessionId/redeem`
   - `GET /api/seller/context`
   - `GET /api/seller/publishability`
+  - `GET /api/seller/shipping-profiles`
+  - `POST /api/seller/shipping-profiles`
+  - `GET /api/seller/shipping-profiles/:shippingProfileId`
+  - `PATCH /api/seller/shipping-profiles/:shippingProfileId`
   - `POST /api/seller/listings`
   - `GET /api/seller/listings/:listingId`
   - `PATCH /api/seller/listings/:listingId`
@@ -83,6 +87,9 @@
 - The preferred OpenClaw bootstrap is the browser handoff flow. `/seller/settings` remains the manual fallback for creating an API key directly in CMD Market.
 - Development eligibility override is ignored in production, even if `DEV_SELLER_OVERRIDE_EMAILS` is set.
 - Seller API keys authenticate seller API routes only. Browser seller UI still requires a browser session.
+- Shipping is currently flat domestic shipping for the `US 50 states + DC` only.
+- Sellers manage reusable shipping profiles and attach one `shipping_profile_id` to each listing draft before publish.
+- Seller listing responses and public listing responses now include a normalized `shipping` summary block.
 - Draft upload sessions are listing-scoped and currently expect a `listing_id` plus image file descriptors.
 - Trading-card authoring currently uses one seeded category:
   - `cat_cards`
@@ -150,7 +157,20 @@ The current OpenClaw handoff is safe for public clients because CMD Market store
 
 ## Listing Authoring API Flow
 
-1. Create a blank draft listing:
+1. Create a reusable shipping profile:
+   ```bash
+   curl -X POST http://localhost:3000/api/seller/shipping-profiles \
+     -H "x-api-key: <seller-api-key>" \
+     -H "content-type: application/json" \
+     -d '{
+       "name": "Card mailer",
+       "domestic_rate_minor": 499,
+       "handling_time_days": 2
+     }'
+   ```
+   CMD Market returns a seller-owned `shipping_profile` resource scoped to flat domestic `USD` shipping for the `US 50 states + DC`.
+
+2. Create a blank draft listing:
    ```bash
    curl -X POST http://localhost:3000/api/seller/listings \
      -H "x-api-key: <seller-api-key>" \
@@ -168,13 +188,15 @@ The current OpenClaw handoff is safe for public clients because CMD Market store
        "description": "Clean slab, no cracks, centered well.",
        "condition_code": "used_good",
        "quantity_available": 1,
+       "shipping_profile_id": "shp_123",
        "price": {
          "amount_minor": 125000,
          "currency_code": "USD"
        }
      }'
    ```
-2. Request draft-scoped upload sessions:
+   Draft creation accepts `shipping_profile_id` up front, and publish validation requires a seller-owned shipping profile before the draft can go live.
+3. Request draft-scoped upload sessions:
    ```bash
    curl -X POST http://localhost:3000/api/seller/upload-sessions \
      -H "x-api-key: <seller-api-key>" \
@@ -190,8 +212,8 @@ The current OpenClaw handoff is safe for public clients because CMD Market store
        ]
      }'
    ```
-3. Upload the file bytes directly to Spaces with the returned presigned `PUT` URL and `content-type` header.
-4. Attach the uploaded asset to the draft:
+4. Upload the file bytes directly to Spaces with the returned presigned `PUT` URL and `content-type` header.
+5. Attach the uploaded asset to the draft:
    ```bash
    curl -X POST http://localhost:3000/api/seller/listings/lst_123/media \
      -H "x-api-key: <seller-api-key>" \
@@ -205,16 +227,17 @@ The current OpenClaw handoff is safe for public clients because CMD Market store
      }'
    ```
    `alt_text` is optional, and `sort_order` is optional. If you omit `sort_order`, CMD Market defaults it from the media array order.
-5. Discover the current category metadata before patching attributes:
+6. Discover the current category metadata before patching attributes:
    ```bash
    curl http://localhost:3000/api/categories/trading-cards
    ```
-6. Patch the draft with trading-card fields and attributes:
+7. Patch the draft with trading-card fields and attributes:
    ```bash
    curl -X PATCH http://localhost:3000/api/seller/listings/lst_123 \
      -H "x-api-key: <seller-api-key>" \
      -H "content-type: application/json" \
      -d '{
+       "shipping_profile_id": "shp_123",
        "title": "1999 Charizard Holo PSA 8",
        "description": "Clean slab, no cracks, centered well.",
        "condition_code": "used_good",

--- a/docs/plans/active/2026-03-25-marketplace-api-design.md
+++ b/docs/plans/active/2026-03-25-marketplace-api-design.md
@@ -508,6 +508,7 @@ Purpose:
 Supports:
 
 - public access
+- canonical flat domestic shipping summary from the attached seller shipping profile
 - optional related includes
 
 ### `GET /api/sellers/{seller_slug}`
@@ -548,6 +549,11 @@ Request contract:
 - `listing_id` is required
 - `quantity` required
 - `shipping_address` required
+- `shipping_address.country_code` must be `US`
+- `shipping_address.region` must be one of the `50 states + DC`
+- non-U.S. destinations, territories, and military mail are rejected
+- `shipping_minor` is copied directly from the listing's attached flat domestic shipping profile
+- no carrier rating call occurs during checkout in this slice
 - no cart model
 
 ### `GET /api/orders`
@@ -639,6 +645,53 @@ Notes:
 - this endpoint creates presigned S3-compatible upload requests for DigitalOcean Spaces
 - the response returns an `asset_key` that matches the object key persisted in marketplace tables
 
+### `GET /api/seller/shipping-profiles`
+
+Purpose:
+
+- list reusable seller-owned flat domestic shipping profiles
+
+Auth:
+
+- seller session or seller API key
+
+### `POST /api/seller/shipping-profiles`
+
+Purpose:
+
+- create a reusable seller-owned flat domestic shipping profile
+
+Auth:
+
+- seller session or seller API key
+
+Notes:
+
+- shipping is currently fixed to `US 50 states + DC`
+- `domestic_rate_minor` is stored in `USD` minor units
+- `0` means free shipping
+- `handling_time_days` is constrained to `1 | 2 | 3`
+
+### `GET /api/seller/shipping-profiles/{shipping_profile_id}`
+
+Purpose:
+
+- fetch one seller-owned shipping profile
+
+Auth:
+
+- seller session or seller API key
+
+### `PATCH /api/seller/shipping-profiles/{shipping_profile_id}`
+
+Purpose:
+
+- update one seller-owned shipping profile
+
+Auth:
+
+- seller session or seller API key
+
 ### `POST /api/seller/listings`
 
 Purpose:
@@ -652,6 +705,8 @@ Auth:
 Notes:
 
 - returns a draft listing resource
+- `shipping_profile_id` is optional at create time
+- publish validation requires a seller-owned shipping profile before the listing can go live
 - no publish occurs here
 
 ### `GET /api/seller/listings`
@@ -674,6 +729,10 @@ Auth:
 
 - seller session or seller API key
 
+Notes:
+
+- includes both `shipping_profile_id` and the normalized `shipping` summary
+
 ### `PATCH /api/seller/listings/{listing_id}`
 
 Purpose:
@@ -683,6 +742,10 @@ Purpose:
 Auth:
 
 - seller session or seller API key
+
+Notes:
+
+- accepts `shipping_profile_id` to attach or replace the flat domestic shipping profile on the draft
 
 ### `POST /api/seller/listings/{listing_id}/media`
 
@@ -801,6 +864,36 @@ The marketplace API should not duplicate API key creation, rotation, or revocati
 
 ## Listing Draft And Publish Workflow
 
+### Step 0: create a shipping profile
+
+Request:
+
+`POST /api/seller/shipping-profiles`
+
+```json
+{
+  "name": "Card mailer",
+  "domestic_rate_minor": 499,
+  "handling_time_days": 2
+}
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "id": "shp_01JQSHIP",
+    "object": "shipping_profile",
+    "name": "Card mailer",
+    "domestic_rate_minor": 499,
+    "currency_code": "USD",
+    "handling_time_days": 2,
+    "scope": "us_50_states"
+  }
+}
+```
+
 ### Step 1: create a draft
 
 Request:
@@ -814,6 +907,7 @@ Request:
   "description": "Clean slab, no cracks, centered well.",
   "condition_code": "used_good",
   "quantity_available": 1,
+  "shipping_profile_id": "shp_01JQSHIP",
   "price": {
     "amount_minor": 125000,
     "currency_code": "USD"
@@ -835,6 +929,14 @@ Response:
       "slug": "trading-cards",
       "name": "Trading Cards"
     },
+    "shipping_profile_id": "shp_01JQSHIP",
+    "shipping": {
+      "mode": "flat",
+      "scope": "us_50_states",
+      "domestic_rate_minor": 499,
+      "currency_code": "USD",
+      "handling_time_days": 2
+    },
     "management": {
       "draft_validation": {
         "publishable": false,
@@ -843,6 +945,16 @@ Response:
             "field": "media",
             "code": "minimum_items_not_met",
             "message": "At least one image is required."
+          },
+          {
+            "field": "attributes.grading_company",
+            "code": "required",
+            "message": "Grading Company is required for this category."
+          },
+          {
+            "field": "attributes.grade",
+            "code": "required",
+            "message": "Grade is required for this category."
           }
         ]
       }
@@ -915,6 +1027,7 @@ Request:
 
 ```json
 {
+  "shipping_profile_id": "shp_01JQSHIP",
   "attributes": [
     {
       "key": "grading_company",
@@ -978,6 +1091,8 @@ There is no cart in v1.
 
 An order is created from a listing.
 
+This buyer checkout contract is still planned, not yet implemented in the current repo.
+
 Request:
 
 `POST /api/orders`
@@ -1008,9 +1123,9 @@ Response:
     "buyer_kind": "anonymous",
     "totals": {
       "subtotal_minor": 125000,
-      "shipping_minor": 1500,
+      "shipping_minor": 499,
       "platform_fee_minor": 0,
-      "total_minor": 126500,
+      "total_minor": 125499,
       "currency_code": "USD"
     }
   }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,11 +18,12 @@ The repo now uses a mix of targeted behavior tests and repo-level verification:
 - `apps/web/app/seller/authorize/openclaw/[browserToken]/actions.test.ts` covers the browser handoff actions, including inline first-workspace creation failures and redirects.
 - `apps/web/lib/seller/http.test.ts` covers seller response envelopes shared by runtime JSON and OpenAPI generation.
 - `apps/web/lib/listing/service.test.ts` covers blank draft creation, draft-scoped upload session creation, media attachment, cross-seller rejection, and duplicate-attachment handling.
-- `apps/web/lib/listing/service.draft-publish.test.ts` covers real listing draft fields, typed trading-card attributes, category reads, publish validation, and public listing reads.
+- `apps/web/lib/listing/service.draft-publish.test.ts` covers real listing draft fields, seller-owned shipping profile attachment, typed trading-card attributes, category reads, publish validation, and public listing reads.
 - `apps/web/lib/listing/domain.test.ts` covers draft publish-validation rules and the Problem Details payload.
 - `apps/web/lib/listing/http.test.ts` covers listing response envelopes shared by runtime JSON and OpenAPI generation.
+- `apps/web/lib/shipping-profile/service.test.ts` and `apps/web/lib/shipping-profile/http.test.ts` cover seller-owned shipping profile validation, ownership, and shared response envelopes.
 - `apps/web/lib/discovery/llms.test.ts` and `apps/web/lib/discovery/openapi.test.ts` cover the generated discovery documents.
-- `apps/web/prisma/schema.test.ts` covers the checked-in seller eligibility, listing/media schema, and seeded category/attribute metadata shape.
+- `apps/web/prisma/schema.test.ts` covers the checked-in seller eligibility, listing/media/shipping schema, and seeded category/attribute metadata shape.
 - `apps/web/app/_components/landing/content.test.ts` and `apps/web/app/seller/content.test.ts` cover public-surface copy contracts for the homepage and seller entry page.
 
 ## Manual Verification
@@ -45,7 +46,11 @@ The repo now uses a mix of targeted behavior tests and repo-level verification:
   - development override only appears outside production and only for allowlisted sellers
   - `GET /api/seller/context`
   - `GET /api/seller/publishability`
+  - `POST /api/seller/shipping-profiles` creates a reusable flat domestic shipping profile
+  - `GET /api/seller/shipping-profiles` lists the seller-owned shipping profiles for the current seller context
   - `POST /api/seller/listings` returns a `draft` listing and still accepts an empty `{}` body
+  - `POST /api/seller/listings` and `PATCH /api/seller/listings/:listingId` accept `shipping_profile_id`
+  - seller listing responses include both `shipping_profile_id` and the normalized `shipping` summary
   - `GET /api/categories`
   - `GET /api/categories/trading-cards`
   - `POST /api/seller/upload-sessions` accepts `listing_id` plus image descriptors and returns presigned Spaces `PUT` instructions
@@ -54,7 +59,7 @@ The repo now uses a mix of targeted behavior tests and repo-level verification:
   - `PATCH /api/seller/listings/:listingId` stores trading-card base fields plus `grading_company` and `grade`
   - `POST /api/seller/listings/:listingId/publish` returns `422 listing_validation_failed` for incomplete drafts
   - `POST /api/seller/listings/:listingId/publish` succeeds after required media and trading-card fields are present
-  - `GET /api/listings/:listingId` returns `404` before publish and a canonical public listing after publish
+  - `GET /api/listings/:listingId` returns `404` before publish and a canonical public listing with normalized flat domestic shipping after publish
   - the draft/upload/attach flow works once with a browser session and once with `x-api-key`
 
 ## Direction


### PR DESCRIPTION
## Summary
- add seller-owned flat domestic shipping profiles and listing shipping_profile_id support
- expose normalized shipping on seller/public listing resources and in discovery docs/OpenAPI
- add Prisma migration, validation hardening, and tests for shipping profile flows

## Verification
- pnpm --filter @cmd-market/web test
- pnpm --filter @cmd-market/web typecheck
- pnpm --filter @cmd-market/web lint
- pnpm --filter @cmd-market/web build